### PR TITLE
Enable mouse-driven cube layers without java.awt.Rectangle

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -1,12 +1,9 @@
 package main;
 
 import java.awt.Color;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.KeyAdapter;
 import java.awt.event.KeyEvent;
 import javax.swing.JFrame;
-import javax.swing.Timer;
 
 public class Cubo extends JFrame {
 
@@ -18,10 +15,17 @@ public class Cubo extends JFrame {
     private int size = 80;
     private boolean lines = true;
     private boolean ejeSubcubo = false;
-    private boolean incrementingSize = true;
-    private Timer timer;
     private int lastX;
     private int lastY;
+
+    private int[][] buttons = {
+        {700, 50, 80, 20},  // front
+        {700, 80, 80, 20},  // back
+        {700, 110, 80, 20}, // left
+        {700, 140, 80, 20}, // right
+        {700, 170, 80, 20}, // up
+        {700, 200, 80, 20}  // down
+    };
 
     public Cubo() {
         initComponents();
@@ -48,6 +52,56 @@ public class Cubo extends JFrame {
             }
         }
 
+    }
+
+    private void rotateLayer(int axis, int layer, boolean clockwise) {
+        Subcubo[][][] nuevo = new Subcubo[3][3][3];
+        for (int x = 0; x < 3; x++) {
+            for (int y = 0; y < 3; y++) {
+                for (int z = 0; z < 3; z++) {
+                    nuevo[x][y][z] = cuboRubik[x][y][z];
+                }
+            }
+        }
+
+        for (int x = 0; x < 3; x++) {
+            for (int y = 0; y < 3; y++) {
+                for (int z = 0; z < 3; z++) {
+                    if ((axis == 0 && x == layer) || (axis == 1 && y == layer) || (axis == 2 && z == layer)) {
+                        int nx = x, ny = y, nz = z;
+                        if (axis == 0) { // X
+                            if (clockwise) {
+                                ny = 2 - z;
+                                nz = y;
+                            } else {
+                                ny = z;
+                                nz = 2 - y;
+                            }
+                        } else if (axis == 1) { // Y
+                            if (clockwise) {
+                                nx = z;
+                                nz = 2 - x;
+                            } else {
+                                nx = 2 - z;
+                                nz = x;
+                            }
+                        } else { // Z
+                            if (clockwise) {
+                                nx = 2 - y;
+                                ny = x;
+                            } else {
+                                nx = y;
+                                ny = 2 - x;
+                            }
+                        }
+                        nuevo[nx][ny][nz] = cuboRubik[x][y][z];
+                        nuevo[nx][ny][nz].rotateColors(axis, clockwise);
+                    }
+                }
+            }
+        }
+
+        cuboRubik = nuevo;
     }
 
     private void moverCubo() {
@@ -151,9 +205,6 @@ public class Cubo extends JFrame {
                     case KeyEvent.VK_X:
                         size += 5;
                         break;
-                    case KeyEvent.VK_SPACE:
-                        startAnimation();
-                        break;
                     case KeyEvent.VK_B:
                         if (!lines) {
                             lines = true;
@@ -187,6 +238,23 @@ public class Cubo extends JFrame {
                 if (javax.swing.SwingUtilities.isRightMouseButton(e)) {
                     lastX = e.getX();
                     lastY = e.getY();
+                } else if (javax.swing.SwingUtilities.isLeftMouseButton(e)) {
+                    int mx = e.getX();
+                    int my = e.getY();
+                    if (inButton(0, mx, my)) {
+                        rotateLayer(2, 2, true);
+                    } else if (inButton(1, mx, my)) {
+                        rotateLayer(2, 0, true);
+                    } else if (inButton(2, mx, my)) {
+                        rotateLayer(0, 0, true);
+                    } else if (inButton(3, mx, my)) {
+                        rotateLayer(0, 2, true);
+                    } else if (inButton(4, mx, my)) {
+                        rotateLayer(1, 2, true);
+                    } else if (inButton(5, mx, my)) {
+                        rotateLayer(1, 0, true);
+                    }
+                    moverCubo();
                 }
             }
         });
@@ -219,41 +287,6 @@ public class Cubo extends JFrame {
         setVisible(true);
     }
 
-    private void startAnimation() {
-        if (timer == null) {
-            timer = new Timer(50, new ActionListener() {
-                @Override
-                public void actionPerformed(ActionEvent e) {
-                    anguloX += 2;
-                    anguloY += 2;
-                    anguloZ += 2;
-
-                    // Ajustar el tamaño
-                    if (incrementingSize) {
-                        size += 5;
-                        if (size >= 185) {
-                            incrementingSize = false;
-                        }
-                    } else {
-                        size -= 5;
-                        if (size <= 50) {
-                            incrementingSize = true;
-                        }
-                    }
-
-                    moverCubo();
-                }
-            });
-            timer.start();
-        } else {
-            if (timer.isRunning()) {
-                timer.stop();
-            } else {
-                timer.start();
-            }
-        }
-    }
-
     private void drawUI() {
         PixelFont.drawString(graficos, "RUBIK 3D", 10, 20, 4, Color.WHITE);
         int y = 60;
@@ -261,8 +294,20 @@ public class Cubo extends JFrame {
         PixelFont.drawString(graficos, "WASD MOVE", 10, y, 2, Color.WHITE); y += step;
         PixelFont.drawString(graficos, "RIGHT DRAG ROTATE", 10, y, 2, Color.WHITE); y += step;
         PixelFont.drawString(graficos, "MOUSE WHEEL SCALE", 10, y, 2, Color.WHITE); y += step;
-        PixelFont.drawString(graficos, "SPACE ANIMATE", 10, y, 2, Color.WHITE); y += step;
         PixelFont.drawString(graficos, "B TOGGLE LINES", 10, y, 2, Color.WHITE); y += step;
-        PixelFont.drawString(graficos, "E CHANGE AXIS", 10, y, 2, Color.WHITE);
+        PixelFont.drawString(graficos, "E CHANGE AXIS", 10, y, 2, Color.WHITE); y += step;
+        PixelFont.drawString(graficos, "CLICK BUTTONS TO ROTATE", 10, y, 2, Color.WHITE);
+
+        String[] names = {"FRONT", "BACK", "LEFT", "RIGHT", "UP", "DOWN"};
+        for (int i = 0; i < buttons.length; i++) {
+            int[] b = buttons[i];
+            graficos.drawRect(b[0], b[1], b[0] + b[2], b[1] + b[3], Color.WHITE);
+            PixelFont.drawString(graficos, names[i], b[0] + 5, b[1] + 5, 2, Color.WHITE);
+        }
+    }
+
+    private boolean inButton(int idx, int x, int y) {
+        int[] b = buttons[idx];
+        return x >= b[0] && x <= b[0] + b[2] && y >= b[1] && y <= b[1] + b[3];
     }
 }

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -53,6 +53,51 @@ public class Subcubo {
         };
     }
 
+    public void rotateColors(int axis, boolean clockwise) {
+        Color[] c = Arrays.copyOf(colores, colores.length);
+        switch (axis) {
+            case 0: // X axis
+                if (clockwise) {
+                    colores[1] = c[3]; // front = top
+                    colores[2] = c[1]; // bottom = front
+                    colores[0] = c[2]; // back = bottom
+                    colores[3] = c[0]; // top = back
+                } else {
+                    colores[1] = c[2];
+                    colores[2] = c[0];
+                    colores[0] = c[3];
+                    colores[3] = c[1];
+                }
+                break;
+            case 1: // Y axis
+                if (clockwise) {
+                    colores[5] = c[1]; // right = front
+                    colores[0] = c[5]; // back = right
+                    colores[4] = c[0]; // left = back
+                    colores[1] = c[4]; // front = left
+                } else {
+                    colores[4] = c[1];
+                    colores[0] = c[4];
+                    colores[5] = c[0];
+                    colores[1] = c[5];
+                }
+                break;
+            case 2: // Z axis
+                if (clockwise) {
+                    colores[4] = c[3]; // left = top
+                    colores[2] = c[4]; // bottom = left
+                    colores[5] = c[2]; // right = bottom
+                    colores[3] = c[5]; // top = right
+                } else {
+                    colores[5] = c[3];
+                    colores[2] = c[5];
+                    colores[4] = c[2];
+                    colores[3] = c[4];
+                }
+                break;
+        }
+    }
+
     public void dibujar(Graficos g, double escala, double anguloX, double anguloY, double anguloZ, int trasX, int trasY, int trasZ, boolean lines) {
         double[][] rotadas = new double[8][3];
         for (int i = 0; i < 8; i++) {


### PR DESCRIPTION
## Summary
- drop Swing animation utility and the `java.awt.Rectangle` button objects
- define manual button coordinates in an array
- check clicks against these coordinates to rotate cube layers

## Testing
- `javac -cp src -d build/classes $(find src/main -name "*.java")`
- `java -cp build/classes main.Cubo` *(fails: java.awt.HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_6866f9866d08833081535b3973ccf1ea