### PR TITLE
Fix double buffering usage

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -160,6 +160,7 @@ public class Cubo extends JFrame {
             }
         }
         drawUI();
+        graficos.repaint();
     }
 
     public static void main(String[] args) {

--- a/src/main/Graficos.java
+++ b/src/main/Graficos.java
@@ -20,7 +20,6 @@ public class Graficos extends Canvas {
     public Graficos(int width, int height) {
         this.WIDTH = width;
         this.HEIGHT = height;
-        this.buffer = buffer;
 
         buffer = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB);
         canvas = new boolean [width][height];
@@ -111,7 +110,6 @@ public class Graficos extends Canvas {
                 }
             }
         }
-        repaint();
     }
 
     public void drawLine(int x1, int y1, int x2, int y2, Color color) {
@@ -143,7 +141,6 @@ public class Graficos extends Canvas {
                 y1 += sy;
             }
         }
-        repaint();
     }
 
     public void drawThickLine(int x0, int y0, int x1, int y1, int thickness, Color color) {
@@ -169,7 +166,6 @@ public class Graficos extends Canvas {
                 }
             }
         }
-        repaint();
     }
 
     public void drawCircle(int x0, int y0, int RADIO, Color color) {
@@ -187,7 +183,6 @@ public class Graficos extends Canvas {
             putPixel(x0 - y, y0 + x, color);
             putPixel(x0 - x, y0 + y, color);
         }
-        repaint();
     }
 
     public void drawDottedCircle(int x0, int y0, int radio, Color color) {
@@ -213,7 +208,6 @@ public class Graficos extends Canvas {
                 drawDots(x0, y0, x, y, color);
             }
         }
-        repaint();
     }
 
     private void drawDots(int xc, int yc, int x, int y, Color c) {
@@ -279,7 +273,6 @@ public class Graficos extends Canvas {
             }
         }
 
-        repaint();
     }
 
     public void putPixel(int x, int y, Color color) {


### PR DESCRIPTION
## Summary
- remove redundant `repaint()` calls from drawing routines
- cleanup buffer initialization
- repaint canvas once after drawing the whole cube

## Testing
- `javac $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6867048192e483309bda33fb3b9bf17d