### PR TITLE
Fix rendering artifacts and smoother rotations

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -37,19 +37,14 @@ public class Cubo extends JFrame {
     }
 
     private void setSubcube() {
-        cuboRubik = new Subcubo[3][3][3];  // Cambiar a 3x3x3 para tener 27 subcubos
-
-        int offsetX = -size;
-        int offsetY = -size;
-        int offsetZ = -size;
+        cuboRubik = new Subcubo[3][3][3];
 
         for (int x = 0; x < 3; x++) {
             for (int y = 0; y < 3; y++) {
                 for (int z = 0; z < 3; z++) {
-                    // Ajustar las posiciones para los 27 subcubos
-                    int posX = (int) ((x - 1) * size * escala) + offsetX;
-                    int posY = (int) ((y - 1) * size * escala) + offsetY;
-                    int posZ = (int) ((z - 1) * size * escala) + offsetZ;
+                    int posX = (int) ((x - 1) * size * escala);
+                    int posY = (int) ((y - 1) * size * escala);
+                    int posZ = (int) ((z - 1) * size * escala);
                     cuboRubik[x][y][z] = new Subcubo(posX, posY, posZ, size);
                 }
             }
@@ -144,7 +139,7 @@ public class Cubo extends JFrame {
     private void rotateLayerAnimated(int axis, int layer, boolean clockwise) {
         int dir = clockwise ? 1 : -1;
         double offset = (layer - 1) * size;
-        for (int a = 0; a <= 90; a += 15) {
+        for (int a = 0; a <= 90; a += 10) {
             graficos.clear();
             for (int x = 0; x < 3; x++) {
                 for (int y = 0; y < 3; y++) {

--- a/src/main/Graficos.java
+++ b/src/main/Graficos.java
@@ -38,15 +38,8 @@ public class Graficos extends Canvas {
         int ny1 = Math.max(y0, y1);
 
         for (int y = ny0; y <= ny1; y++) {
-            int xInicio = -1;
             for (int x = nx0; x <= nx1; x++) {
-                if (xInicio == -1) {
-                    xInicio = x;
-                }
-                if (xInicio != -1) {
-                    putPixel(xInicio, y, color);
-                    xInicio = -1;
-                }
+                putPixel(x, y, color);
             }
         }
     }


### PR DESCRIPTION
## Summary
- correct rectangle drawing routine that broke screen clearing
- simplify subcube positioning
- smooth face rotation animation

## Testing
- `javac src/main/*.java -d /tmp/classes`

------
https://chatgpt.com/codex/tasks/task_e_68670ffa87e88330bb9c2962360d33a9