### PR TITLE
Fix flickering by using BufferStrategy

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -202,7 +202,7 @@ public class Cubo extends JFrame {
                         info.x, info.y, (int) info.depth, lines, info.highlight);
             }
             drawUI();
-            graficos.repaint();
+            graficos.render();
 
             ang[0] += 10;
             if (ang[0] > 90) {
@@ -273,7 +273,7 @@ public class Cubo extends JFrame {
             }
         }
         drawUI();
-        graficos.repaint();
+        graficos.render();
     }
 
     private void scrambleAnimation() {
@@ -460,6 +460,7 @@ public class Cubo extends JFrame {
         });
 
         setVisible(true);
+        graficos.initBufferStrategy();
     }
 
     private void drawUI() {

--- a/src/main/Graficos.java
+++ b/src/main/Graficos.java
@@ -3,7 +3,9 @@ package main;
 import java.awt.Canvas;
 import java.awt.Color;
 import java.awt.Graphics;
+import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
+import java.awt.image.BufferStrategy;
 
 public class Graficos extends Canvas {
 
@@ -11,6 +13,7 @@ public class Graficos extends Canvas {
     private final int HEIGHT;
     private BufferedImage buffer;
     private boolean[][] canvas;
+    private BufferStrategy strategy;
 
 
     // Variables para la traslación
@@ -20,10 +23,14 @@ public class Graficos extends Canvas {
     public Graficos(int width, int height) {
         this.WIDTH = width;
         this.HEIGHT = height;
-        this.buffer = buffer;
-
         buffer = new BufferedImage(WIDTH, HEIGHT, BufferedImage.TYPE_INT_ARGB);
         canvas = new boolean [width][height];
+        setIgnoreRepaint(true);
+    }
+
+    public void initBufferStrategy() {
+        createBufferStrategy(2);
+        strategy = getBufferStrategy();
     }
 
     public void fillRect(int x0, int y0, int x1, int y1, Color color) {
@@ -277,13 +284,28 @@ public class Graficos extends Canvas {
 
     @Override
     public void paint(Graphics g) {
-        super.paint(g);
-        g.drawImage(buffer, 0, 0, this);
+        render();
     }
 
     @Override
     public void update(Graphics g) {
-        paint(g);
+        render();
+    }
+
+    public void render() {
+        if (strategy == null) {
+            Graphics gTemp = getGraphics();
+            if (gTemp != null) {
+                gTemp.drawImage(buffer, 0, 0, null);
+                gTemp.dispose();
+            }
+            return;
+        }
+        Graphics g = strategy.getDrawGraphics();
+        g.drawImage(buffer, 0, 0, null);
+        g.dispose();
+        strategy.show();
+        Toolkit.getDefaultToolkit().sync();
     }
     
     public void clear() {


### PR DESCRIPTION
## Summary
- use `BufferStrategy` inside `Graficos` to handle drawing
- call `initBufferStrategy` once the frame is visible
- replace `repaint()` calls with `render()` for explicit buffer flips

## Testing
- `javac @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_6867176e4f2c8330b1f0ec1ddce89c94