### PR TITLE
Add temporary subcube labels

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -48,8 +48,10 @@ public class Cubo extends JFrame {
         final double depth;
         final double ex, ey, ez;
         final boolean highlight;
+        final int ix, iy, iz;
 
-        RenderInfo(Subcubo c, int x, int y, double depth, double ex, double ey, double ez, boolean h) {
+        RenderInfo(Subcubo c, int x, int y, double depth, double ex, double ey,
+                   double ez, boolean h, int ix, int iy, int iz) {
             this.cubo = c;
             this.x = x;
             this.y = y;
@@ -58,6 +60,9 @@ public class Cubo extends JFrame {
             this.ey = ey;
             this.ez = ez;
             this.highlight = h;
+            this.ix = ix;
+            this.iy = iy;
+            this.iz = iz;
         }
     }
 
@@ -256,7 +261,7 @@ public class Cubo extends JFrame {
                         int finalY = (int) (rotatedPos[1] + trasY);
                         int finalZ = (int) (rotatedPos[2] + trasZ);
                         infos.add(new RenderInfo(cuboRubik[x][y][z], finalX, finalY, finalZ,
-                                extraX, extraY, extraZ, highlight));
+                                extraX, extraY, extraZ, highlight, x, y, z));
                     }
                 }
             }
@@ -264,7 +269,7 @@ public class Cubo extends JFrame {
             for (RenderInfo info : infos) {
                 info.cubo.dibujar(graficos, 1.0, anguloX, anguloY, anguloZ,
                         info.x, info.y, (int) info.depth, lines, info.highlight,
-                        info.ex, info.ey, info.ez);
+                        info.ex, info.ey, info.ez, true, info.ix, info.iy, info.iz);
             }
             drawUI();
             graficos.render();
@@ -343,7 +348,7 @@ public class Cubo extends JFrame {
                         int finalZ = (int) (rotatedPos[2] + trasZ);
 
                         boolean highlight = gameMode && x == selX && y == selY && z == selZ;
-                        infos.add(new RenderInfo(cuboRubik[x][y][z], finalX, finalY, finalZ, 0, 0, 0, highlight));
+                        infos.add(new RenderInfo(cuboRubik[x][y][z], finalX, finalY, finalZ, 0, 0, 0, highlight, x, y, z));
                     }
                 }
             }
@@ -351,7 +356,7 @@ public class Cubo extends JFrame {
             for (RenderInfo info : infos) {
                  info.cubo.dibujar(graficos, 1, anguloX, anguloY, anguloZ,
                         info.x, info.y, (int) info.depth, lines, info.highlight,
-                        info.ex, info.ey, info.ez);
+                        info.ex, info.ey, info.ez, true, info.ix, info.iy, info.iz);
             }
         } else {
             graficos.clear();
@@ -360,7 +365,8 @@ public class Cubo extends JFrame {
                 for (int y = 0; y < 3; y++) {
                     for (int z = 0; z < 3; z++) {
                         boolean highlight = gameMode && x == selX && y == selY && z == selZ;
-                        cuboRubik[x][y][z].dibujar(graficos, 1.0, anguloX, anguloY, anguloZ, trasX, trasY, trasZ, lines, highlight);
+                        cuboRubik[x][y][z].dibujar(graficos, 1.0, anguloX, anguloY, anguloZ,
+                                trasX, trasY, trasZ, lines, highlight, 0, 0, 0, true, x, y, z);
                     }
                 }
             }

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -174,6 +174,15 @@ public class Subcubo {
     public void dibujar(Graficos g, double escala, double anguloX, double anguloY, double anguloZ,
             int trasX, int trasY, int trasZ, boolean lines, boolean highlight,
             double extraRotX, double extraRotY, double extraRotZ) {
+        dibujar(g, escala, anguloX, anguloY, anguloZ, trasX, trasY, trasZ,
+                lines, highlight, extraRotX, extraRotY, extraRotZ,
+                false, 0, 0, 0);
+    }
+
+    public void dibujar(Graficos g, double escala, double anguloX, double anguloY, double anguloZ,
+            int trasX, int trasY, int trasZ, boolean lines, boolean highlight,
+            double extraRotX, double extraRotY, double extraRotZ,
+            boolean showLabels, int idxX, int idxY, int idxZ) {
         double[][] rotadas = new double[8][3];
         for (int i = 0; i < 8; i++) {
             double[] local = rotar(vertices[i], rotX + extraRotX, rotY + extraRotY, rotZ + extraRotZ);
@@ -206,11 +215,19 @@ public class Subcubo {
                 xPoints[j] = (int) trasladadas[caras[i][j]][0];
                 yPoints[j] = (int) trasladadas[caras[i][j]][1];
             }
-            g.fillPolygon(xPoints, yPoints, 4, colores[i]); // Pintar caraas
+            g.fillPolygon(xPoints, yPoints, 4, colores[i]); // Pintar caras
             if (lines) {
                 for (int j = 0; j < 4; j++) {
                     int next = (j + 1) % 4;
                     g.drawLine(xPoints[j], yPoints[j], xPoints[next], yPoints[next], Color.BLACK);
+                }
+            }
+            if (showLabels) {
+                String label = getFaceLabel(i, idxX, idxY, idxZ);
+                if (label != null) {
+                    int cx = (xPoints[0] + xPoints[1] + xPoints[2] + xPoints[3]) / 4;
+                    int cy = (yPoints[0] + yPoints[1] + yPoints[2] + yPoints[3]) / 4;
+                    PixelFont.drawString(g, label, cx - 4, cy - 4, 1, Color.BLACK);
                 }
             }
         }
@@ -233,6 +250,19 @@ public class Subcubo {
                 }
             }
             g.drawRect(minX, minY, maxX, maxY, Color.YELLOW);
+        }
+    }
+
+    private String getFaceLabel(int face, int ix, int iy, int iz) {
+        switch (face) {
+            case 1: // front
+                return "A" + (iy * 3 + ix + 1);
+            case 5: // right
+                return "B" + (iy * 3 + (2 - iz) + 1);
+            case 3: // top
+                return "C" + ((2 - iz) * 3 + ix + 1);
+            default:
+                return null;
         }
     }
 


### PR DESCRIPTION
## Summary
- label visible faces of each subcube with A/B/C numbering
- extend `Subcubo.dibujar` to support showing labels
- include subcube indices in render info

## Testing
- `javac @sources.txt`
- `ant -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688039e38e208330aef893008f72fb67