### PR TITLE
Arregla orden de etiquetas en la cara trasera

### DIFF
--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -266,7 +266,7 @@ public class Subcubo {
             case 2: // bottom
                 return "E" + (iz * 3 + ix + 1);
             case 0: // back
-                return "F" + (iy * 3 + (2 - ix) + 1);
+                return "F" + (iy * 3 + ix + 1);
             default:
                 return null;
         }


### PR DESCRIPTION
## Summary
- corrige la numeración de la cara posterior del cubo para que siga un orden
  de izquierda a derecha

## Testing
- `javac -d build/classes src/main/*.java`
- `java -cp build/classes main.Cubo` *(falla: "No X11 DISPLAY variable was set")*

------
https://chatgpt.com/codex/tasks/task_e_6880463ba80083309e5ceda4d6553883