### PR TITLE
Fix cube rotation directions

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -429,10 +429,10 @@ public class Cubo extends JFrame {
                         trasY += 5;
                         break;
                     case KeyEvent.VK_I:
-                        anguloX += 5;
+                        anguloX -= 5;
                         break;
                     case KeyEvent.VK_K:
-                        anguloX -= 5;
+                        anguloX += 5;
                         break;
                     case KeyEvent.VK_L:
                         anguloY += 5;
@@ -441,10 +441,10 @@ public class Cubo extends JFrame {
                         anguloY -= 5;
                         break;
                     case KeyEvent.VK_U:
-                        anguloZ -= 5;
+                        anguloZ += 5;
                         break;
                     case KeyEvent.VK_O:
-                        anguloZ += 5;
+                        anguloZ -= 5;
                         break;
                     case KeyEvent.VK_Z:
                         size -= 5;
@@ -475,7 +475,7 @@ public class Cubo extends JFrame {
                             if (layer < 0) layer = m[1];
                             rotateLayerAnimated(m[0], layer, true);
                         } else if (!gameMode) {
-                            anguloX += 5;
+                            anguloX -= 5;
                         }
                         break;
                     case KeyEvent.VK_DOWN:
@@ -485,7 +485,7 @@ public class Cubo extends JFrame {
                             if (layer < 0) layer = m[1];
                             rotateLayerAnimated(m[0], layer, false);
                         } else if (!gameMode) {
-                            anguloX -= 5;
+                            anguloX += 5;
                         }
                         break;
                     case KeyEvent.VK_LEFT:
@@ -495,7 +495,7 @@ public class Cubo extends JFrame {
                             if (layer < 0) layer = m[1];
                             rotateLayerAnimated(m[0], layer, false);
                         } else if (!gameMode) {
-                            anguloY += 5;
+                            anguloY -= 5;
                         }
                         break;
                     case KeyEvent.VK_RIGHT:
@@ -505,7 +505,7 @@ public class Cubo extends JFrame {
                             if (layer < 0) layer = m[1];
                             rotateLayerAnimated(m[0], layer, true);
                         } else if (!gameMode) {
-                            anguloY -= 5;
+                            anguloY += 5;
                         }
                         break;
                     case KeyEvent.VK_R:
@@ -578,14 +578,14 @@ public class Cubo extends JFrame {
                             int t = size / 2;
                             if (Math.abs(dx) > t && Math.abs(dy) > t) {
                                 if ((dx > 0 && dy < 0) || (dx < 0 && dy > 0)) {
-                                    anguloZ += 5;
-                                } else {
                                     anguloZ -= 5;
+                                } else {
+                                    anguloZ += 5;
                                 }
                             } else if (Math.abs(dx) <= t && dy < -t) {
-                                anguloX += 5;
-                            } else if (Math.abs(dx) <= t && dy > t) {
                                 anguloX -= 5;
+                            } else if (Math.abs(dx) <= t && dy > t) {
+                                anguloX += 5;
                             } else if (Math.abs(dy) <= t && dx < -t) {
                                 anguloY -= 5;
                             } else if (Math.abs(dy) <= t && dx > t) {


### PR DESCRIPTION
## Summary
- fix directions for keyboard cube rotations
- match mouse click rotations to keyboard behavior

## Testing
- `javac -d out $(find src -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_68817731d5008330ba2525220fab63eb