### PR TITLE
Restrict corner drag rotation

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -633,9 +633,11 @@ public class Cubo extends JFrame {
                     }
                     if (idxX != -1) {
                         int dx = cx - trasX, dy = cy - trasY;
-                        boolean corner = (idxX == 0 || idxX == 2) &&
-                                         (idxY == 0 || idxY == 2) &&
-                                         (idxZ == 0 || idxZ == 2);
+                        // Only treat the four front-face corners (F1, F3, F7, F9)
+                        // as Z-axis drag handles
+                        boolean corner = idxZ == 2 &&
+                                         (idxX == 0 || idxX == 2) &&
+                                         (idxY == 0 || idxY == 2);
                         if (corner) {
                             // --- ESQUINA: eje Z (como O/U) ---
                             draggingCorner = true;


### PR DESCRIPTION
## Summary
- limit corner-based Z rotation to the four front-face corners

## Testing
- ❌ `ant -noinput -q jar` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882ee7cfc4c8330aa7971612763b70f