### PR TITLE
Enable rotation by dragging on cube faces

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -61,6 +61,10 @@ public class Cubo extends JFrame {
      */
     private boolean draggingCorner = false;
     /**
+     * Indica si se está arrastrando un subcubo de cara para rotar en X/Y.
+     */
+    private boolean draggingFace = false;
+    /**
      * Modo de juego en el que se puede seleccionar subcubos.
      */
     private boolean gameMode = false;
@@ -639,6 +643,7 @@ public class Cubo extends JFrame {
                         if (corner) {
                             // --- ESQUINA: eje Z (como O/U) ---
                             draggingCorner = true;
+                            draggingFace = false;
                             lastX = e.getX();
                             lastY = e.getY();
                             if ((dx > 0 && dy < 0) || (dx < 0 && dy > 0)) {
@@ -648,6 +653,10 @@ public class Cubo extends JFrame {
                             }
                         } else {
                             // --- RESTO DE SUBCUBOS: ejes X/Y como flechas ---
+                            draggingFace = true;
+                            draggingCorner = false;
+                            lastX = e.getX();
+                            lastY = e.getY();
                             if (Math.abs(dx) >= Math.abs(dy)) {
                                 if (dx < 0) {
                                     // Izquierda (J/←)
@@ -673,6 +682,7 @@ public class Cubo extends JFrame {
             @Override
             public void mouseReleased(MouseEvent e) {
                 draggingCorner = false;
+                draggingFace = false;
             }
         });
 
@@ -686,6 +696,13 @@ public class Cubo extends JFrame {
                     double vy2 = e.getY() - trasY;
                     double cross = vx1 * vy2 - vy1 * vx2;
                     applyRotation(2, cross / 1000.0);
+                    lastX = e.getX();
+                    lastY = e.getY();
+                    moverCubo();
+                } else if (!gameMode && draggingFace && (e.getModifiersEx() & InputEvent.BUTTON1_DOWN_MASK) != 0) {
+                    int dx = e.getX() - lastX, dy = e.getY() - lastY;
+                    applyRotation(1, -dx / 2.0);
+                    applyRotation(0, dy / 2.0);
                     lastX = e.getX();
                     lastY = e.getY();
                     moverCubo();


### PR DESCRIPTION
## Summary
- allow subcube face dragging with left mouse button to rotate the view around X/Y
- maintain existing corner dragging behaviour for Z rotation

## Testing
- `ant clean jar` *(fails: ant not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6882ee7cfc4c8330aa7971612763b70f