### PR TITLE
Ensure RenderPanel gains focus for key events

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -898,6 +898,10 @@ public class Cubo extends JFrame {
             moverCubo();
         });
 
+        // El panel debe poder enfocarse para captar las teclas
+        panel.setFocusable(true);
+        panel.requestFocusInWindow(); // Asegura la recepción de eventos de teclado
+
         setVisible(true);
     }
 


### PR DESCRIPTION
## Summary
- request focus for `RenderPanel` so keyboard input is captured

## Testing
- `javac -d build/classes $(find src/main -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6884458f96e88330b06336c5529bd14d