### PR TITLE
Mix cube only in play mode

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -714,7 +714,7 @@ public class Cubo extends JFrame {
                         break;
 
                     case KeyEvent.VK_R:
-                        if (!gameMode) {
+                        if (gameMode) {
                             scrambleAnimation();
                         }
                         break;
@@ -982,6 +982,8 @@ public class Cubo extends JFrame {
         y += step;
         PixelFont.drawString(graficos, "N TOGGLE LABELS", 10, y, 3, Color.WHITE);
         y += step;
-        PixelFont.drawString(graficos, "R MIX CUBE", 10, y, 3, Color.WHITE);
+        if (gameMode) {
+            PixelFont.drawString(graficos, "R MIX CUBE", 10, y, 3, Color.WHITE);
+        }
     }
 }


### PR DESCRIPTION
## Summary
- enable cube scrambling only in play mode (gameMode)
- hide the mix instruction unless game mode is active

## Testing
- `javac -d out $(find src -name '*.java')`
- `java -cp out main.Cubo` *(fails: no X11 DISPLAY)*

------
https://chatgpt.com/codex/tasks/task_e_688453acbca083308a51f5e75ccb4190