### PR TITLE
Remove unused variables in moverCubo

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -499,14 +499,10 @@ public class Cubo extends JFrame {
             for (int x = 0; x < 3; x++) {
                 for (int y = 0; y < 3; y++) {
                     for (int z = 0; z < 3; z++) {
-                        // Calcular las nuevas coordenadas rotadas alrededor del subcubo 14
-                        int newX = centroX + (x - centroX);
-                        int newY = centroY + (y - centroY);
-                        int newZ = centroZ + (z - centroZ);
-
-                        double posX = (newX - 1) * size;
-                        double posY = (newY - 1) * size;
-                        double posZ = (newZ - 1) * size;
+                        // Posición relativa al centro del cubo
+                        double posX = (x - 1) * size;
+                        double posY = (y - 1) * size;
+                        double posZ = (z - 1) * size;
 
                         // Aplicar las rotaciones alrededor del subcubo 14
                         double[] rotatedPos = cuboRubik[x][y][z].rotar(new double[]{posX, posY, posZ}, anguloX, anguloY, anguloZ);


### PR DESCRIPTION
## Summary
- simplify `moverCubo` by removing unused `newX`, `newY` and `newZ`

## Testing
- `javac` compile all `src` files

------
https://chatgpt.com/codex/tasks/task_e_6884737606188330bbccb121d4bd492f