### PR TITLE
Add helper for arrow key rotations

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -298,6 +298,16 @@ public class Cubo extends JFrame {
         }
     }
 
+    // Determina el eje y sentido de rotación según el vector de la flecha
+    // pulsada y la cara seleccionada. Devuelve {axis, clockwiseFlag}
+    private int[] getArrowRotation(double[] arrowVec, int face) {
+        double[] normal = getFaceNormal(face);
+        double[] axisVec = cross(arrowVec, normal);
+        int axis = mapDirection(axisVec)[0];
+        boolean clockwise = axisVec[axis] < 0;
+        return new int[]{axis, clockwise ? 1 : 0};
+    }
+
     // ----- Ayudas para detectar la cara y esquinas visibles -----
     private static final double EPS = 0.1;
 
@@ -699,12 +709,10 @@ public class Cubo extends JFrame {
                     case KeyEvent.VK_UP:
                         if (gameMode && selX != -1) {
                             double[] arrowVec = rotateVector(new double[]{0, 1, 0}, -anguloX, -anguloY, -anguloZ);
-                            double[] normal = getFaceNormal(selFace);
-                            double[] dir = cross(normal, arrowVec);
-                            int[] m = mapDirection(dir);
-                            int axis = m[0];
+                            int[] rot = getArrowRotation(arrowVec, selFace);
+                            int axis = rot[0];
                             int layer = axis == 0 ? selX : axis == 1 ? selY : selZ;
-                            boolean cw = dir[axis] < 0;
+                            boolean cw = rot[1] == 1;
                             rotateLayerAnimated(axis, layer, cw);
                         }
                         break;
@@ -724,12 +732,10 @@ public class Cubo extends JFrame {
                     case KeyEvent.VK_DOWN:
                         if (gameMode && selX != -1) {
                             double[] arrowVec = rotateVector(new double[]{0, -1, 0}, -anguloX, -anguloY, -anguloZ);
-                            double[] normal = getFaceNormal(selFace);
-                            double[] dir = cross(normal, arrowVec);
-                            int[] m = mapDirection(dir);
-                            int axis = m[0];
+                            int[] rot = getArrowRotation(arrowVec, selFace);
+                            int axis = rot[0];
                             int layer = axis == 0 ? selX : axis == 1 ? selY : selZ;
-                            boolean cw = dir[axis] < 0;
+                            boolean cw = rot[1] == 1;
                             rotateLayerAnimated(axis, layer, cw);
                         }
                         break;
@@ -751,12 +757,10 @@ public class Cubo extends JFrame {
                     case KeyEvent.VK_LEFT:
                         if (gameMode && selX != -1) {
                             double[] arrowVec = rotateVector(new double[]{-1, 0, 0}, -anguloX, -anguloY, -anguloZ);
-                            double[] normal = getFaceNormal(selFace);
-                            double[] dir = cross(normal, arrowVec);
-                            int[] m = mapDirection(dir);
-                            int axis = m[0];
+                            int[] rot = getArrowRotation(arrowVec, selFace);
+                            int axis = rot[0];
                             int layer = axis == 0 ? selX : axis == 1 ? selY : selZ;
-                            boolean cw = dir[axis] > 0;
+                            boolean cw = rot[1] == 1;
                             rotateLayerAnimated(axis, layer, cw);
                         }
                         break;
@@ -776,12 +780,10 @@ public class Cubo extends JFrame {
                     case KeyEvent.VK_RIGHT:
                         if (gameMode && selX != -1) {
                             double[] arrowVec = rotateVector(new double[]{1, 0, 0}, -anguloX, -anguloY, -anguloZ);
-                            double[] normal = getFaceNormal(selFace);
-                            double[] dir = cross(normal, arrowVec);
-                            int[] m = mapDirection(dir);
-                            int axis = m[0];
+                            int[] rot = getArrowRotation(arrowVec, selFace);
+                            int axis = rot[0];
                             int layer = axis == 0 ? selX : axis == 1 ? selY : selZ;
-                            boolean cw = dir[axis] > 0;
+                            boolean cw = rot[1] == 1;
                             rotateLayerAnimated(axis, layer, cw);
                         }
                         break;


### PR DESCRIPTION
## Summary
- centralize arrow key rotation logic in Cubo
- compute axis and direction based on the selected face and arrow vector
- use the helper when handling arrow keys

## Testing
- `javac`

------
https://chatgpt.com/codex/tasks/task_e_688488071dcc83309533725ab34f3f1f