### PR TITLE
Fix layer rotation directions

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -153,6 +153,8 @@ public class Cubo extends JFrame {
      */
     private void rotateLayer(int axis, int layer, boolean clockwise) {
         Subcubo[][][] nuevo = new Subcubo[3][3][3];
+
+        // Copiar todas las piezas inicialmente
         for (int x = 0; x < 3; x++) {
             for (int y = 0; y < 3; y++) {
                 for (int z = 0; z < 3; z++) {
@@ -161,36 +163,46 @@ public class Cubo extends JFrame {
             }
         }
 
+        // Aplicar la rotación a la capa indicada
         for (int x = 0; x < 3; x++) {
             for (int y = 0; y < 3; y++) {
                 for (int z = 0; z < 3; z++) {
-                    if ((axis == 0 && x == layer) || (axis == 1 && y == layer) || (axis == 2 && z == layer)) {
+                    if ((axis == 0 && x == layer) ||
+                        (axis == 1 && y == layer) ||
+                        (axis == 2 && z == layer)) {
+
                         int nx = x, ny = y, nz = z;
-                        if (axis == 0) { // X
-                            if (clockwise) {
-                                ny = 2 - z;
-                                nz = y;
-                            } else {
-                                ny = z;
-                                nz = 2 - y;
-                            }
-                        } else if (axis == 1) { // Y
-                            if (clockwise) {
-                                nx = z;
-                                nz = 2 - x;
-                            } else {
-                                nx = 2 - z;
-                                nz = x;
-                            }
-                        } else { // Z
-                            if (clockwise) {
-                                nx = 2 - y;
-                                ny = x;
-                            } else {
-                                nx = y;
-                                ny = 2 - x;
-                            }
+
+                        switch (axis) {
+                            case 0: // X
+                                if (clockwise) {
+                                    ny = z;
+                                    nz = 2 - y;
+                                } else {
+                                    ny = 2 - z;
+                                    nz = y;
+                                }
+                                break;
+                            case 1: // Y
+                                if (clockwise) {
+                                    nx = 2 - z;
+                                    nz = x;
+                                } else {
+                                    nx = z;
+                                    nz = 2 - x;
+                                }
+                                break;
+                            case 2: // Z
+                                if (clockwise) {
+                                    nx = y;
+                                    ny = 2 - x;
+                                } else {
+                                    nx = 2 - y;
+                                    ny = x;
+                                }
+                                break;
                         }
+
                         nuevo[nx][ny][nz] = cuboRubik[x][y][z];
                         nuevo[nx][ny][nz].rotateColors(axis, clockwise);
                         nuevo[nx][ny][nz].rotateOrientation(axis, clockwise);

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -101,43 +101,41 @@ public class Subcubo {
         switch (axis) {
             case 0: // X axis
                 if (clockwise) {
-                    colores[1] = c[3]; // front = top
-                    colores[2] = c[1]; // bottom = front
-                    colores[0] = c[2]; // back = bottom
-                    colores[3] = c[0]; // top = back
-                } else {
                     colores[1] = c[2];
                     colores[2] = c[0];
                     colores[0] = c[3];
                     colores[3] = c[1];
+                } else {
+                    colores[1] = c[3]; // front = top
+                    colores[2] = c[1]; // bottom = front
+                    colores[0] = c[2]; // back = bottom
+                    colores[3] = c[0]; // top = back
                 }
                 break;
             case 1: // Y axis
                 if (clockwise) {
-                    colores[5] = c[1]; // right = front
-                    colores[0] = c[5]; // back = right
-                    colores[4] = c[0]; // left = back
-                    colores[1] = c[4]; // front = left
-                } else {
                     colores[4] = c[1];
                     colores[0] = c[4];
                     colores[5] = c[0];
                     colores[1] = c[5];
+                } else {
+                    colores[5] = c[1]; // right = front
+                    colores[0] = c[5]; // back = right
+                    colores[4] = c[0]; // left = back
+                    colores[1] = c[4]; // front = left
                 }
                 break;
             case 2: // Z axis
                 if (clockwise) {
-                    // top -> right -> bottom -> left -> top
-                    colores[5] = c[3]; // right = top
-                    colores[2] = c[5]; // bottom = right
-                    colores[4] = c[2]; // left = bottom
-                    colores[3] = c[4]; // top = left
-                } else {
-                    // top -> left -> bottom -> right -> top
                     colores[4] = c[3]; // left = top
                     colores[2] = c[4]; // bottom = left
                     colores[5] = c[2]; // right = bottom
                     colores[3] = c[5]; // top = right
+                } else {
+                    colores[5] = c[3]; // right = top
+                    colores[2] = c[5]; // bottom = right
+                    colores[4] = c[2]; // left = bottom
+                    colores[3] = c[4]; // top = left
                 }
                 break;
         }
@@ -147,7 +145,7 @@ public class Subcubo {
      * Actualiza la rotación acumulada de la pieza.
      */
     public void rotateOrientation(int axis, boolean clockwise) {
-        double ang = clockwise ? 90 : -90;
+        double ang = clockwise ? -90 : 90;
         switch (axis) {
             case 0:
                 rotX = (rotX + ang) % 360;


### PR DESCRIPTION
## Summary
- simplify layer rotation math
- invert clockwise/counter-clockwise logic in Subcubo
- keep orientation rotation in sync

## Testing
- `javac -cp src -d /tmp/classes $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_688490d4c8a48330952233de110ebaed