### PR TITLE
Disable color rotation in Cubo

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -204,7 +204,8 @@ public class Cubo extends JFrame {
                         }
 
                         nuevo[nx][ny][nz] = cuboRubik[x][y][z];
-                        nuevo[nx][ny][nz].rotateColors(axis, clockwise);
+                        // Colors will be scrambled; orientation only
+                        // nuevo[nx][ny][nz].rotateColors(axis, clockwise);
                         nuevo[nx][ny][nz].rotateOrientation(axis, clockwise);
                     }
                 }

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -94,54 +94,6 @@ public class Subcubo {
     }
 
     /**
-     * Rota los colores de las caras cuando la pieza gira alrededor de un eje.
-     */
-    public void rotateColors(int axis, boolean clockwise) {
-        Color[] c = Arrays.copyOf(colores, colores.length);
-        switch (axis) {
-            case 0: // X axis
-                if (clockwise) {
-                    colores[1] = c[2];
-                    colores[2] = c[0];
-                    colores[0] = c[3];
-                    colores[3] = c[1];
-                } else {
-                    colores[1] = c[3]; // front = top
-                    colores[2] = c[1]; // bottom = front
-                    colores[0] = c[2]; // back = bottom
-                    colores[3] = c[0]; // top = back
-                }
-                break;
-            case 1: // Y axis
-                if (clockwise) {
-                    colores[4] = c[1];
-                    colores[0] = c[4];
-                    colores[5] = c[0];
-                    colores[1] = c[5];
-                } else {
-                    colores[5] = c[1]; // right = front
-                    colores[0] = c[5]; // back = right
-                    colores[4] = c[0]; // left = back
-                    colores[1] = c[4]; // front = left
-                }
-                break;
-            case 2: // Z axis
-                if (clockwise) {
-                    colores[4] = c[3]; // left = top
-                    colores[2] = c[4]; // bottom = left
-                    colores[5] = c[2]; // right = bottom
-                    colores[3] = c[5]; // top = right
-                } else {
-                    colores[5] = c[3]; // right = top
-                    colores[2] = c[5]; // bottom = right
-                    colores[4] = c[2]; // left = bottom
-                    colores[3] = c[4]; // top = left
-                }
-                break;
-        }
-    }
-
-    /**
      * Actualiza la rotación acumulada de la pieza.
      */
     public void rotateOrientation(int axis, boolean clockwise) {


### PR DESCRIPTION
## Summary
- comment out calls to `rotateColors` when rotating layers
- remove the now-unused `Subcubo.rotateColors` method

## Testing
- `javac -d build $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_68856b9d9a648330892f57dd8a1af109