### PR TITLE
Maintain Subcubo orientation in 0-359 degrees

### DIFF
--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -100,13 +100,13 @@ public class Subcubo {
         double ang = clockwise ? -90 : 90;
         switch (axis) {
             case 0:
-                rotX = (rotX + ang) % 360;
+                rotX = (rotX + ang + 360) % 360;
                 break;
             case 1:
-                rotY = (rotY + ang) % 360;
+                rotY = (rotY + ang + 360) % 360;
                 break;
             case 2:
-                rotZ = (rotZ + ang) % 360;
+                rotZ = (rotZ + ang + 360) % 360;
                 break;
         }
     }


### PR DESCRIPTION
## Summary
- avoid negative orientation angles by normalizing rotations to 0-359 degrees in Subcubo.rotateOrientation

## Testing
- `ant test` *(fails: command not found)*
- `javac -d /tmp/classes $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_688ad6ee28f083309efed2a941b97260