### PR TITLE
Fix face depth averaging

### DIFF
--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -194,7 +194,7 @@ public class Subcubo {
         double[] profundidades = new double[6];
         for (int i = 0; i < 6; i++) {
             profundidades[i] = (trasladadas[caras[i][0]][2] + trasladadas[caras[i][1]][2]
-                    + trasladadas[caras[i][2]][2] + trasladadas[caras[i][3]][2]) / 2.0;
+                    + trasladadas[caras[i][2]][2] + trasladadas[caras[i][3]][2]) / 4.0;
             faceDepths[i] = profundidades[i];
         }
 


### PR DESCRIPTION
## Summary
- Correct face depth averaging to divide by 4.0 when computing mean depth across four vertices.

## Testing
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_688ae1890b8883309266241a2a80ab50