### PR TITLE
Use RenderOptions to simplify subcube rendering

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -513,11 +513,20 @@ public class Cubo extends JFrame {
             }
             infos.sort((aInfo, bInfo) -> Double.compare(bInfo.depth, aInfo.depth));
             for (RenderInfo info : infos) {
+                RenderOptions opt = new RenderOptions();
+                opt.highlight = info.highlight;
+                opt.extraRotX = info.ex;
+                opt.extraRotY = info.ey;
+                opt.extraRotZ = info.ez;
+                opt.extraTX = info.tx;
+                opt.extraTY = info.ty;
+                opt.extraTZ = info.tz;
+                opt.showLabels = showLabels;
+                opt.idxX = info.ix;
+                opt.idxY = info.iy;
+                opt.idxZ = info.iz;
                 info.cubo.dibujar(graficos, 1.0, anguloX, anguloY, anguloZ,
-                        info.x, info.y, (int) info.depth, lines, info.highlight,
-                        info.ex, info.ey, info.ez,
-                        info.tx, info.ty, info.tz,
-                        showLabels, info.ix, info.iy, info.iz);
+                        info.x, info.y, (int) info.depth, lines, opt);
             }
             drawUI();
             graficos.render();
@@ -638,11 +647,20 @@ public class Cubo extends JFrame {
             }
             infos.sort((a, b) -> Double.compare(b.depth, a.depth));
             for (RenderInfo info : infos) {
+                RenderOptions opt = new RenderOptions();
+                opt.highlight = info.highlight;
+                opt.extraRotX = info.ex;
+                opt.extraRotY = info.ey;
+                opt.extraRotZ = info.ez;
+                opt.extraTX = info.tx;
+                opt.extraTY = info.ty;
+                opt.extraTZ = info.tz;
+                opt.showLabels = showLabels;
+                opt.idxX = info.ix;
+                opt.idxY = info.iy;
+                opt.idxZ = info.iz;
                 info.cubo.dibujar(graficos, 1, anguloX, anguloY, anguloZ,
-                        info.x, info.y, (int) info.depth, lines, info.highlight,
-                        info.ex, info.ey, info.ez,
-                        info.tx, info.ty, info.tz,
-                        showLabels, info.ix, info.iy, info.iz);
+                        info.x, info.y, (int) info.depth, lines, opt);
             }
         } else {
             graficos.clear();
@@ -654,10 +672,17 @@ public class Cubo extends JFrame {
                         double tX = highlight ? selTX : 0;
                         double tY = highlight ? selTY : 0;
                         double tZ = highlight ? selTZ : 0;
+                        RenderOptions opt = new RenderOptions();
+                        opt.highlight = highlight;
+                        opt.extraTX = tX;
+                        opt.extraTY = tY;
+                        opt.extraTZ = tZ;
+                        opt.showLabels = showLabels;
+                        opt.idxX = x;
+                        opt.idxY = y;
+                        opt.idxZ = z;
                         cuboRubik[x][y][z].dibujar(graficos, 1.0, anguloX, anguloY, anguloZ,
-                                trasX, trasY, trasZ, lines, highlight, 0, 0, 0,
-                                tX, tY, tZ,
-                                showLabels, x, y, z);
+                                trasX, trasY, trasZ, lines, opt);
                     }
                 }
             }

--- a/src/main/RenderOptions.java
+++ b/src/main/RenderOptions.java
@@ -1,0 +1,17 @@
+package main;
+
+/**
+ * Opciones de renderizado para un Subcubo.
+ */
+public class RenderOptions {
+    /** Indica si la pieza debe resaltarse. */
+    public boolean highlight = false;
+    /** Rotaciones adicionales en cada eje. */
+    public double extraRotX = 0, extraRotY = 0, extraRotZ = 0;
+    /** Traslaciones adicionales en el espacio. */
+    public double extraTX = 0, extraTY = 0, extraTZ = 0;
+    /** Mostrar etiquetas de las caras. */
+    public boolean showLabels = false;
+    /** Índices del subcubo para etiquetado. */
+    public int idxX = 0, idxY = 0, idxZ = 0;
+}

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -207,38 +207,26 @@ public class Subcubo {
         return rotar(local, rotX, rotY, rotZ);
     }
 
-    // Método de compatibilidad para versiones previas sin el parámetro highlight
-    public void dibujar(Graficos g, double escala, double anguloX, double anguloY, double anguloZ, int trasX, int trasY, int trasZ, boolean lines) {
-        dibujar(g, escala, anguloX, anguloY, anguloZ, trasX, trasY, trasZ, lines,
-                false, 0, 0, 0, 0, 0, 0, false, 0, 0, 0);
-    }
-
     /**
      * Dibuja el subcubo aplicando las transformaciones indicadas.
      */
-    public void dibujar(Graficos g, double escala, double anguloX, double anguloY, double anguloZ, int trasX, int trasY, int trasZ, boolean lines, boolean highlight) {
-        dibujar(g, escala, anguloX, anguloY, anguloZ, trasX, trasY, trasZ, lines,
-                highlight, 0, 0, 0, 0, 0, 0, false, 0, 0, 0);
-    }
-
-    /**
-     * Dibuja el subcubo con rotaciones adicionales opcionales utilizadas para
-     * animaciones.
-     */
     public void dibujar(Graficos g, double escala, double anguloX, double anguloY, double anguloZ,
-            int trasX, int trasY, int trasZ, boolean lines, boolean highlight,
-            double extraRotX, double extraRotY, double extraRotZ) {
-        dibujar(g, escala, anguloX, anguloY, anguloZ, trasX, trasY, trasZ,
-                lines, highlight, extraRotX, extraRotY, extraRotZ,
-                0, 0, 0,
-                false, 0, 0, 0);
-    }
+            int trasX, int trasY, int trasZ, boolean lines, RenderOptions opt) {
+        if (opt == null) {
+            opt = new RenderOptions();
+        }
+        boolean highlight = opt.highlight;
+        double extraRotX = opt.extraRotX;
+        double extraRotY = opt.extraRotY;
+        double extraRotZ = opt.extraRotZ;
+        double extraTX = opt.extraTX;
+        double extraTY = opt.extraTY;
+        double extraTZ = opt.extraTZ;
+        boolean showLabels = opt.showLabels;
+        int idxX = opt.idxX;
+        int idxY = opt.idxY;
+        int idxZ = opt.idxZ;
 
-    public void dibujar(Graficos g, double escala, double anguloX, double anguloY, double anguloZ,
-            int trasX, int trasY, int trasZ, boolean lines, boolean highlight,
-            double extraRotX, double extraRotY, double extraRotZ,
-            double extraTX, double extraTY, double extraTZ,
-            boolean showLabels, int idxX, int idxY, int idxZ) {
         double[][] rotadas = new double[8][3];
         for (int i = 0; i < 8; i++) {
             double[] local = rotar(vertices[i], rotX + extraRotX, rotY + extraRotY, rotZ + extraRotZ);


### PR DESCRIPTION
## Summary
- Introduce `RenderOptions` to carry highlight flags, animation rotations, translations and labeling indices
- Replace four `Subcubo.dibujar` overloads with a single method using `RenderOptions`
- Update `Cubo` to build and pass `RenderOptions` when drawing subcubes

## Testing
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `javac -d build $(find src/main -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_688af215a0848330bbdfa07c83062345