### PR TITLE
Handle zero-length lines in thick drawing

### DIFF
--- a/src/main/Graficos.java
+++ b/src/main/Graficos.java
@@ -183,9 +183,17 @@ public class Graficos {
         int dx = x1 - x0;
         int dy = y1 - y0;
         double distance = Math.sqrt(dx * dx + dy * dy);
+        int halfThickness = thickness / 2;
+
+        // Si la distancia es cero, dibuja un pequeño cuadrado y termina
+        if (distance == 0) {
+            fillRect(x0 - halfThickness, y0 - halfThickness,
+                     x0 + halfThickness, y0 + halfThickness, color);
+            return;
+        }
+
         double unitDx = dx / distance;
         double unitDy = dy / distance;
-        int halfThickness = thickness / 2;
 
         for (int i = -halfThickness; i <= halfThickness; i++) {
             int xOffset = (int) (i * unitDy);   // desplazamiento perpendicular en X


### PR DESCRIPTION
## Summary
- Avoid division-by-zero when drawing thick lines by checking for zero-length segments and rendering a small square instead.
- Compute perpendicular unit vectors only when the segment has non-zero length.

## Testing
- `javac -d build $(find src/main -name "*.java")`
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `javac -d build -cp build $(find test -name "*.java")` *(fails: missing JUnit packages)*

------
https://chatgpt.com/codex/tasks/task_e_68941c51699c8330809e68a2ef4d6add