### PR TITLE
Reorder paintComponent Javadoc

### DIFF
--- a/src/main/RenderPanel.java
+++ b/src/main/RenderPanel.java
@@ -20,10 +20,10 @@ public class RenderPanel extends JPanel {
         setPreferredSize(new java.awt.Dimension(graficos.getWidth(), graficos.getHeight()));
     }
 
-    @Override
     /**
      * Pinta en pantalla la última imagen generada.
      */
+    @Override
     protected void paintComponent(java.awt.Graphics g) {
         super.paintComponent(g);
         BufferedImage img = graficos.getBuffer();


### PR DESCRIPTION
## Summary
- Move paintComponent Javadoc above the `@Override` annotation in RenderPanel
- Ensure file ends with newline

## Testing
- `ant test` *(fails: command not found)*
- `apt-get install -y ant` *(fails: Unable to locate package ant)*

------
https://chatgpt.com/codex/tasks/task_e_68941c3d55948330aeb694c54197d8b4