### PR TITLE
Wrap Cubo creation in SwingUtilities.invokeLater

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -715,7 +715,7 @@ public class Cubo extends JFrame {
     }
 
     public static void main(String[] args) {
-        new Cubo();
+        SwingUtilities.invokeLater(Cubo::new);
     }
 
     private void initComponents() {


### PR DESCRIPTION
## Summary
- ensure Cubo GUI is created on the Swing event dispatch thread using `SwingUtilities.invokeLater`

## Testing
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894203935788330889a9a18f1a584f4