### PR TITLE
Remove unused center variables

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -613,11 +613,6 @@ public class Cubo extends JFrame {
         if (!ejeSubcubo) {
             graficos.clear();
 
-            // Encontrar el centro del cubo
-            int centroX = 1;
-            int centroY = 1;
-            int centroZ = 1; // Coordenadas del subcubo 14
-
             java.util.List<RenderInfo> infos = new java.util.ArrayList<>();
             for (int x = 0; x < 3; x++) {
                 for (int y = 0; y < 3; y++) {


### PR DESCRIPTION
## Summary
- remove unused `centroX`, `centroY`, and `centroZ` from cube rendering logic

## Testing
- `ant jar` *(fails: command not found)*
- `apt-get install -y ant` *(fails: Unable to locate package ant)*
- `javac src/main/*.java`


------
https://chatgpt.com/codex/tasks/task_e_68981ebc690083309da96a9c9e480faf