### PR TITLE
Fix typo in controls help text

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -1152,7 +1152,7 @@ public class Cubo extends JFrame {
         y += step;
         PixelFont.drawString(graficos, "N TOGGLE LABELS", 10, y, 2, Color.WHITE);
         y += step;
-        PixelFont.drawString(graficos, "H SHOW CONTROLLS", 10, y, 2, Color.WHITE);
+        PixelFont.drawString(graficos, "H SHOW CONTROLS", 10, y, 2, Color.WHITE);
         y += step;
 
     }


### PR DESCRIPTION
## Summary
- Correct typo in help screen to display `H SHOW CONTROLS`

## Testing
- `javac src/main/*.java`
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68981ee37b088330ac82560af0cf2a9a