### PR TITLE
Update subcube indices after layer rotation

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -209,9 +209,13 @@ public class Cubo extends JFrame {
                                 break;
                         }
 
-                        nuevo[nx][ny][nz] = cuboRubik[x][y][z];
-                        nuevo[nx][ny][nz].rotateColors(axis, clockwise);
-                        nuevo[nx][ny][nz].rotateOrientation(axis, clockwise);
+                        Subcubo moved = cuboRubik[x][y][z];
+                        nuevo[nx][ny][nz] = moved;
+                        moved.x = nx;
+                        moved.y = ny;
+                        moved.z = nz;
+                        moved.rotateColors(axis, clockwise);
+                        moved.rotateOrientation(axis, clockwise);
                     }
                 }
             }

--- a/test/main/RotateLayerCoordinateTest.java
+++ b/test/main/RotateLayerCoordinateTest.java
@@ -1,0 +1,48 @@
+package main;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class RotateLayerCoordinateTest {
+
+    @Test
+    public void subcubeIndicesUpdateOnRotateLayer() throws Exception {
+        System.setProperty("java.awt.headless", "true");
+        Method rotateLayer = Cubo.class.getDeclaredMethod("rotateLayer", int.class, int.class, boolean.class);
+        rotateLayer.setAccessible(true);
+        Field cuboField = Cubo.class.getDeclaredField("cuboRubik");
+        cuboField.setAccessible(true);
+
+        for (int axis = 0; axis < 3; axis++) {
+            for (int layer = 0; layer < 3; layer++) {
+                Cubo c = new Cubo();
+                Subcubo[][][] cubo = (Subcubo[][][]) cuboField.get(c);
+                for (int x = 0; x < 3; x++) {
+                    for (int y = 0; y < 3; y++) {
+                        for (int z = 0; z < 3; z++) {
+                            cubo[x][y][z].x = x;
+                            cubo[x][y][z].y = y;
+                            cubo[x][y][z].z = z;
+                        }
+                    }
+                }
+                rotateLayer.invoke(c, axis, layer, true);
+                cubo = (Subcubo[][][]) cuboField.get(c);
+                for (int x = 0; x < 3; x++) {
+                    for (int y = 0; y < 3; y++) {
+                        for (int z = 0; z < 3; z++) {
+                            Subcubo sc = cubo[x][y][z];
+                            assertEquals(x, sc.x);
+                            assertEquals(y, sc.y);
+                            assertEquals(z, sc.z);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update rotateLayer to write each subcube's new x, y, z indices
- add unit test checking subcube coordinates after each layer rotation

## Testing
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y ant` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68982d9beecc8330ad3ba840dd2dc2a0