### PR TITLE
Apply translation offsets to dotted circle drawing

### DIFF
--- a/src/main/Graficos.java
+++ b/src/main/Graficos.java
@@ -256,10 +256,6 @@ public class Graficos {
      * Dibuja la circunferencia de un círculo con un patrón de puntos.
      */
     public void drawDottedCircle(int x0, int y0, int radio, Color color) {
-        // Aplicar traslación a la posición base
-        x0 += translateX;
-        y0 += translateY;
-
         int x = 0;
         int y = radio;
         int d = 3 - 2 * radio; // Parámetro de decisión
@@ -267,7 +263,7 @@ public class Graficos {
 
         while (x <= y) {
             if (counter % 10 < 5) { // Controla el patrón de puntos
-                drawDots(x0 - translateX, y0 - translateY, x, y, color);
+                drawDots(x0, y0, x, y, color);
             }
             counter++;
 
@@ -279,7 +275,7 @@ public class Graficos {
                 d = d + 4 * (x - y) + 10;
             }
             if (counter % 10 < 5) { // Controla el patrón de puntos
-                drawDots(x0 - translateX, y0 - translateY, x, y, color);
+                drawDots(x0, y0, x, y, color);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Ensure drawDottedCircle delegates to drawDots with original coordinates so translation is applied once.
- drawDots continues to offset its center by translateX/translateY before plotting pixels.

## Testing
- `javac src/main/*.java`
- `javac src/main/*.java test/main/*.java` *(fails: package org.junit does not exist)*
- `apt-get update` *(fails: 403  Forbidden [IP: 172.30.0.3 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68983238b5d883308e3e1579a1cbcb9a