### PR TITLE
Require face selection for arrow rotations

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -825,7 +825,7 @@ public class Cubo extends JFrame {
                         if (animating) break;
                         if (!gameMode) {
                             applyRotation(0, -5);
-                        } else if (selX != -1) {
+                        } else if (selX != -1 && selFace != -1) {
                             int[] m = getArrowRotation(new double[]{0, -1, 0},
                                     cuboRubik[selX][selY][selZ], selFace);
                             int axis = m[0];
@@ -836,7 +836,7 @@ public class Cubo extends JFrame {
                         break;
                     case KeyEvent.VK_UP:
                         if (animating) break;
-                        if (gameMode && selX != -1) {
+                        if (gameMode && selX != -1 && selFace != -1) {
                             int[] m = getArrowRotation(new double[]{0, -1, 0},
                                     cuboRubik[selX][selY][selZ], selFace);
                             int axis = m[0];
@@ -849,7 +849,7 @@ public class Cubo extends JFrame {
                         if (animating) break;
                         if (!gameMode) {
                             applyRotation(0, 5);
-                        } else if (selX != -1) {
+                        } else if (selX != -1 && selFace != -1) {
                             int[] m = getArrowRotation(new double[]{0, 1, 0},
                                     cuboRubik[selX][selY][selZ], selFace);
                             int axis = m[0];
@@ -860,7 +860,7 @@ public class Cubo extends JFrame {
                         break;
                     case KeyEvent.VK_DOWN:
                         if (animating) break;
-                        if (gameMode && selX != -1) {
+                        if (gameMode && selX != -1 && selFace != -1) {
                             int[] m = getArrowRotation(new double[]{0, 1, 0},
                                     cuboRubik[selX][selY][selZ], selFace);
                             int axis = m[0];
@@ -875,7 +875,7 @@ public class Cubo extends JFrame {
                         if (animating) break;
                         if (!gameMode) {
                             applyRotation(1, 5);  // giro a la izquierda
-                        } else if (selX != -1) {
+                        } else if (selX != -1 && selFace != -1) {
                             int[] m = getArrowRotation(new double[]{-1, 0, 0},
                                     cuboRubik[selX][selY][selZ], selFace);
                             int axis = m[0];
@@ -886,7 +886,7 @@ public class Cubo extends JFrame {
                         break;
                     case KeyEvent.VK_LEFT:
                         if (animating) break;
-                        if (gameMode && selX != -1) {
+                        if (gameMode && selX != -1 && selFace != -1) {
                             int[] m = getArrowRotation(new double[]{-1, 0, 0},
                                     cuboRubik[selX][selY][selZ], selFace);
                             int axis = m[0];
@@ -899,7 +899,7 @@ public class Cubo extends JFrame {
                         if (animating) break;
                         if (!gameMode) {
                             applyRotation(1, -5);  // giro a la derecha
-                        } else if (selX != -1) {
+                        } else if (selX != -1 && selFace != -1) {
                             int[] m = getArrowRotation(new double[]{1, 0, 0},
                                     cuboRubik[selX][selY][selZ], selFace);
                             int axis = m[0];
@@ -910,7 +910,7 @@ public class Cubo extends JFrame {
                         break;
                     case KeyEvent.VK_RIGHT:
                         if (animating) break;
-                        if (gameMode && selX != -1) {
+                        if (gameMode && selX != -1 && selFace != -1) {
                             int[] m = getArrowRotation(new double[]{1, 0, 0},
                                     cuboRubik[selX][selY][selZ], selFace);
                             int axis = m[0];


### PR DESCRIPTION
## Summary
- Ensure rotation hotkeys (I/J/K/L and arrow keys) only trigger when a face is selected
- Prevents accidental layer rotations with no face chosen

## Testing
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68983dabcb188330b42b7ea28ab470b5