### PR TITLE
Adjust subcube size on scroll without reinitialization

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -154,6 +154,23 @@ public class Cubo extends JFrame {
     }
 
     /**
+     * Ajusta el tamaño de las piezas existentes sin reiniciar sus colores ni
+     * orientaciones.
+     *
+     * @param newSize nuevo tamaño en píxeles para cada subcubo
+     */
+    private void resizeSubcubes(int newSize) {
+        size = newSize;
+        for (int x = 0; x < 3; x++) {
+            for (int y = 0; y < 3; y++) {
+                for (int z = 0; z < 3; z++) {
+                    cuboRubik[x][y][z].setSize(newSize);
+                }
+            }
+        }
+    }
+
+    /**
      * Rota una capa completa del cubo modificando orientación y colores de las
      * piezas que la componen.
      */
@@ -1159,11 +1176,11 @@ public class Cubo extends JFrame {
         });
 
         panel.addMouseWheelListener(e -> {
-            size -= e.getWheelRotation() * 5;
-            if (size < 20) {
-                size = 20;
+            int newSize = size - e.getWheelRotation() * 5;
+            if (newSize < 20) {
+                newSize = 20;
             }
-            setSubcube();
+            resizeSubcubes(newSize);
             moverCubo();
         });
 

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -177,6 +177,29 @@ public class Subcubo {
     }
 
     /**
+     * Ajusta el tamaño del subcubo sin reiniciar su orientación ni colores.
+     *
+     * @param newSize nuevo tamaño del subcubo
+     */
+    public void setSize(int newSize) {
+        this.size = newSize;
+        double half = newSize / 2.0;
+        double[][] newVerts = new double[][]{
+            {-half, -half, -half},
+            {half, -half, -half},
+            {half, half, -half},
+            {-half, half, -half},
+            {-half, -half, half},
+            {half, -half, half},
+            {half, half, half},
+            {-half, half, half}
+        };
+        for (int i = 0; i < vertices.length; i++) {
+            System.arraycopy(newVerts[i], 0, vertices[i], 0, 3);
+        }
+    }
+
+    /**
      * Devuelve el vector normal local de una cara según su índice.
      */
     public static double[] getFaceNormal(int face) {


### PR DESCRIPTION
## Summary
- Add ability to resize existing Subcubo instances while keeping orientation and colors
- Replace setSubcube() invocation on mouse wheel with resizeSubcubes() and re-render

## Testing
- `ant test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898431c8eb08330a87624cd78241ca8