### PR TITLE
Improve arrow rotation mapping for side faces

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -395,9 +395,28 @@ public class Cubo extends JFrame {
     private int[] getArrowRotation(double[] arrowVec, Subcubo sc, int face) {
         double[] rArrow = rotateVector(arrowVec, -anguloX, -anguloY, -anguloZ);
         double[] normal = sc.getFaceNormalWorld(face);
-        // Use the face normal and arrow to obtain the rotation axis so that
-        // pressing an arrow key rotates the selected layer following the
-        // arrow direction regardless of the cube orientation.
+
+        // Faces 4 (left) and 5 (right) need explicit mapping so that each
+        // arrow key corresponds to a unique rotation. The normal of these
+        // faces is parallel to the X axis, so up/down arrows should rotate
+        // around X and left/right arrows around Y.
+        if (face == 4 || face == 5) {
+            boolean vertical = Math.abs(arrowVec[1]) >= Math.abs(arrowVec[0]);
+            int axis = vertical ? 0 : 1; // X for vertical arrows, Y otherwise
+            boolean cw;
+            if (vertical) {
+                // Up/down: invert clockwise when looking at the right face
+                cw = (arrowVec[1] > 0) ^ (face == 5);
+            } else {
+                // Left/right: invert clockwise when looking at the right face
+                cw = (arrowVec[0] < 0) ^ (face == 5);
+            }
+            return new int[]{axis, cw ? 1 : 0};
+        }
+
+        // General case: obtain axis from cross product between face normal and
+        // arrow direction. If the arrow is parallel to the normal, fall back to
+        // using the global up or right vectors to decide the axis.
         double[] axisVec = cross(normal, rArrow);
         double thr = 1e-6;
         if (Math.abs(axisVec[0]) < thr && Math.abs(axisVec[1]) < thr && Math.abs(axisVec[2]) < thr) {

--- a/test/main/CuboArrowRotationTest.java
+++ b/test/main/CuboArrowRotationTest.java
@@ -40,15 +40,15 @@ public class CuboArrowRotationTest {
             {0, new double[]{-1, 0, 0}, 1, 0},
             {0, new double[]{1, 0, 0}, 1, 1},
             // left face (4)
-            {4, new double[]{0, -1, 0}, 2, 0},
-            {4, new double[]{0, 1, 0}, 2, 1},
-            {4, new double[]{-1, 0, 0}, 2, 0},
-            {4, new double[]{1, 0, 0}, 2, 1},
+            {4, new double[]{0, -1, 0}, 0, 0},
+            {4, new double[]{0, 1, 0}, 0, 1},
+            {4, new double[]{-1, 0, 0}, 1, 1},
+            {4, new double[]{1, 0, 0}, 1, 0},
             // right face (5)
-            {5, new double[]{0, -1, 0}, 2, 1},
-            {5, new double[]{0, 1, 0}, 2, 0},
-            {5, new double[]{-1, 0, 0}, 2, 0},
-            {5, new double[]{1, 0, 0}, 2, 1},
+            {5, new double[]{0, -1, 0}, 0, 1},
+            {5, new double[]{0, 1, 0}, 0, 0},
+            {5, new double[]{-1, 0, 0}, 1, 0},
+            {5, new double[]{1, 0, 0}, 1, 1},
             // top face (3)
             {3, new double[]{0, -1, 0}, 2, 0},
             {3, new double[]{0, 1, 0}, 2, 1},


### PR DESCRIPTION
## Summary
- ensure `getArrowRotation` maps arrows on left/right faces to the X or Y axis for unique moves
- expand arrow rotation tests for left and right faces

## Testing
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `javac test/main/CuboArrowRotationTest.java` *(fails: package org.junit does not exist)*


------
https://chatgpt.com/codex/tasks/task_e_6898454920388330a5210a208d63bbf9