### PR TITLE
Fix arrow direction mapping for rotated cube

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -401,14 +401,17 @@ public class Cubo extends JFrame {
         // faces is parallel to the X axis, so up/down arrows should rotate
         // around X and left/right arrows around Y.
         if (face == 4 || face == 5) {
-            boolean vertical = Math.abs(arrowVec[1]) >= Math.abs(arrowVec[0]);
+            // Determine arrow orientation using the rotated arrow vector so
+            // that global cube rotations do not affect the mapping.
+            boolean vertical = Math.abs(rArrow[1]) >= Math.abs(rArrow[0]);
             int axis = vertical ? 0 : 1; // X for vertical arrows, Y otherwise
             boolean cw;
             if (vertical) {
-                // Up/down: invert clockwise when looking at the right face
+                // Up/down arrows determine clockwise direction via the
+                // original screen-space arrow vector.
                 cw = (arrowVec[1] > 0) ^ (face == 5);
             } else {
-                // Left/right: invert clockwise when looking at the right face
+                // Left/right arrows determine clockwise direction.
                 cw = (arrowVec[0] < 0) ^ (face == 5);
             }
             return new int[]{axis, cw ? 1 : 0};

--- a/test/main/CuboArrowRotationTest.java
+++ b/test/main/CuboArrowRotationTest.java
@@ -11,6 +11,7 @@ public class CuboArrowRotationTest {
 
     private Cubo cubo;
     private Method getArrow;
+    private Method applyRot;
 
     @Before
     public void setUp() throws Exception {
@@ -18,11 +19,42 @@ public class CuboArrowRotationTest {
         cubo = new Cubo();
         getArrow = Cubo.class.getDeclaredMethod("getArrowRotation", double[].class, Subcubo.class, int.class);
         getArrow.setAccessible(true);
+        applyRot = Cubo.class.getDeclaredMethod("applyRotation", int.class, double.class);
+        applyRot.setAccessible(true);
     }
 
     private int[] call(double[] arrow, int face) throws Exception {
         Subcubo sc = new Subcubo(0, 0, 0, 1);
         return (int[]) getArrow.invoke(cubo, arrow, sc, face);
+    }
+
+    @Test
+    public void testArrowRotationWithCubeRotated() throws Exception {
+        // Rotate cube 90 degrees around Y axis and ensure mapping remains
+        // consistent for the left and right faces regardless of orientation.
+        applyRot.invoke(cubo, 1, 90.0); // rotate around Y
+        Object[][] cases = new Object[][]{
+            // left face (4) after rotation
+            {4, new double[]{0, -1, 0}, 0, 0},
+            {4, new double[]{0, 1, 0}, 0, 1},
+            {4, new double[]{-1, 0, 0}, 1, 0},
+            {4, new double[]{1, 0, 0}, 1, 1},
+            // right face (5) after rotation
+            {5, new double[]{0, -1, 0}, 0, 1},
+            {5, new double[]{0, 1, 0}, 0, 0},
+            {5, new double[]{-1, 0, 0}, 1, 1},
+            {5, new double[]{1, 0, 0}, 1, 0}
+        };
+
+        for (Object[] c : cases) {
+            int face = (Integer) c[0];
+            double[] arrow = (double[]) c[1];
+            int expAxis = (Integer) c[2];
+            int expCw = (Integer) c[3];
+            int[] res = call(arrow, face);
+            assertEquals("axis for face " + face, expAxis, res[0]);
+            assertEquals("cw for face " + face, expCw, res[1]);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Use rotated arrow vector when deciding whether an arrow is vertical or horizontal so cube orientation doesn’t affect the mapping
- Keep clockwise detection consistent and add regression tests for rotated cubes

## Testing
- `ant test` *(fails: command not found)*
- `javac -cp build/classes -d build/test-classes test/main/CuboArrowRotationTest.java` *(fails: package org.junit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68984bbe3ae483309e4acb54508f5700