### PR TITLE
Clear selection when canceling in game mode

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -989,6 +989,7 @@ public class Cubo extends JFrame {
                     case KeyEvent.VK_ESCAPE:
                         if (gameMode) {
                             selX = selY = selZ = -1;
+                            selFace = selMX = selMY = -1;
                             moverCubo();
                         }
                         break;


### PR DESCRIPTION
## Summary
- Reset selected face and mouse indices when ESC is pressed in game mode

## Testing
- `ant test` *(fails: command not found: ant)*
- `java -cp /tmp/classes main.Cubo` *(fails: java.awt.HeadlessException: No X11 DISPLAY variable was set...)*

------
https://chatgpt.com/codex/tasks/task_e_68984e0975b88330a4a2cb19fa69faee