### PR TITLE
Use subcube indices instead of pixel positions

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -143,10 +143,7 @@ public class Cubo extends JFrame {
         for (int x = 0; x < 3; x++) {
             for (int y = 0; y < 3; y++) {
                 for (int z = 0; z < 3; z++) {
-                    int posX = (int) ((x - 1) * size * escala);
-                    int posY = (int) ((y - 1) * size * escala);
-                    int posZ = (int) ((z - 1) * size * escala);
-                    cuboRubik[x][y][z] = new Subcubo(posX, posY, posZ, size);
+                    cuboRubik[x][y][z] = new Subcubo(x, y, z, size);
                 }
             }
         }

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 public class Subcubo {
 
     /**
-     * Posición original de la pieza dentro del cubo completo.
+     * Índices de esta pieza dentro del cubo completo.
      */
     public int x, y, z, size;
     /**
@@ -46,12 +46,12 @@ public class Subcubo {
     private double rotX = 0, rotY = 0, rotZ = 0;
 
     /**
-     * Crea un subcubo en la posición indicada dentro del cubo de Rubik.
+     * Crea un subcubo identificándolo por sus índices dentro del cubo de Rubik.
      */
-    public Subcubo(int x, int y, int z, int size) {
-        this.x = x;
-        this.y = y;
-        this.z = z;
+    public Subcubo(int ix, int iy, int iz, int size) {
+        this.x = ix;
+        this.y = iy;
+        this.z = iz;
         this.size = size;
 
         vertices = new double[][]{
@@ -91,6 +91,21 @@ public class Subcubo {
 
         screenVertices = new int[8][2];
         faceDepths = new double[6];
+    }
+
+    /**
+     * Devuelve la posición absoluta del centro del subcubo en función de su
+     * índice y una escala dada. La escala representa la separación relativa
+     * entre piezas.
+     *
+     * @param escala factor de escala aplicado al tamaño
+     * @return vector de tres componentes con las coordenadas en el espacio
+     */
+    public double[] getPosition(double escala) {
+        double posX = (x - 1) * size * escala;
+        double posY = (y - 1) * size * escala;
+        double posZ = (z - 1) * size * escala;
+        return new double[]{posX, posY, posZ};
     }
 
     /**

--- a/test/main/RotateLayerCoordinateTest.java
+++ b/test/main/RotateLayerCoordinateTest.java
@@ -21,17 +21,22 @@ public class RotateLayerCoordinateTest {
             for (int layer = 0; layer < 3; layer++) {
                 Cubo c = new Cubo();
                 Subcubo[][][] cubo = (Subcubo[][][]) cuboField.get(c);
+
+                // Verificar índices iniciales
                 for (int x = 0; x < 3; x++) {
                     for (int y = 0; y < 3; y++) {
                         for (int z = 0; z < 3; z++) {
-                            cubo[x][y][z].x = x;
-                            cubo[x][y][z].y = y;
-                            cubo[x][y][z].z = z;
+                            Subcubo sc = cubo[x][y][z];
+                            assertEquals(x, sc.x);
+                            assertEquals(y, sc.y);
+                            assertEquals(z, sc.z);
                         }
                     }
                 }
+
                 rotateLayer.invoke(c, axis, layer, true);
                 cubo = (Subcubo[][][]) cuboField.get(c);
+
                 for (int x = 0; x < 3; x++) {
                     for (int y = 0; y < 3; y++) {
                         for (int z = 0; z < 3; z++) {


### PR DESCRIPTION
## Summary
- Instantiate `Subcubo` with index values instead of pixel coordinates
- Adjust `Subcubo` to store indices and derive absolute position when needed
- Update rotation coordinate test to rely on initial indices

## Testing
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease 403 Forbidden)*
- `javac -d out $(find src/main -name '*.java')`


------
https://chatgpt.com/codex/tasks/task_e_689920c873908330838cd487c772d850