### PR TITLE
Align Z-axis rotation with right-hand rule

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -283,18 +283,18 @@ public class Cubo extends JFrame {
             case 2: // Z axis
                 if (clockwise) {
                     switch (face) {
-                        case 2: return 5; // bottom -> right
-                        case 3: return 4; // top -> left
-                        case 4: return 2; // left -> bottom
-                        case 5: return 3; // right -> top
-                        default: return face;
-                    }
-                } else {
-                    switch (face) {
                         case 2: return 4; // bottom -> left
                         case 3: return 5; // top -> right
                         case 4: return 3; // left -> top
                         case 5: return 2; // right -> bottom
+                        default: return face;
+                    }
+                } else {
+                    switch (face) {
+                        case 2: return 5; // bottom -> right
+                        case 3: return 4; // top -> left
+                        case 4: return 2; // left -> bottom
+                        case 5: return 3; // right -> top
                         default: return face;
                     }
                 }

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -176,15 +176,15 @@ public class Subcubo {
                 Color left = colores[4];
                 Color right = colores[5];
                 if (clockwise) {
-                    colores[4] = top;    // left
-                    colores[2] = left;   // bottom
-                    colores[5] = bottom; // right
-                    colores[3] = right;  // top
-                } else {
                     colores[5] = top;    // right
                     colores[2] = right;  // bottom
                     colores[4] = bottom; // left
                     colores[3] = left;   // top
+                } else {
+                    colores[4] = top;    // left
+                    colores[2] = left;   // bottom
+                    colores[5] = bottom; // right
+                    colores[3] = right;  // top
                 }
                 break;
             }


### PR DESCRIPTION
## Summary
- Fix Z-axis color rotation to cycle top→right→bottom→left consistently
- Update face index rotation to match new Z-axis order

## Testing
- `ant test` *(fails: ant not installed)*
- `apt-get update` *(fails: repositories not signed)*
- Manual JShell check of Z-axis rotation order

------
https://chatgpt.com/codex/tasks/task_e_68992376b0e08330bee1e993bd6cf142