### PR TITLE
Handle degenerate arrow rotations

### DIFF
--- a/test/main/CuboArrowRotationTest.java
+++ b/test/main/CuboArrowRotationTest.java
@@ -3,6 +3,7 @@ package main;
 import static org.junit.Assert.*;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Field;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -102,5 +103,37 @@ public class CuboArrowRotationTest {
             assertEquals("axis for face " + face, expAxis, res[0]);
             assertEquals("cw for face " + face, expCw, res[1]);
         }
+    }
+
+    @Test
+    public void testArrowRotationTopBottomDegenerate() throws Exception {
+        Field rotField = Cubo.class.getDeclaredField("rotMatrix");
+        rotField.setAccessible(true);
+        Field ax = Cubo.class.getDeclaredField("anguloX");
+        Field ay = Cubo.class.getDeclaredField("anguloY");
+        Field az = Cubo.class.getDeclaredField("anguloZ");
+        ax.setDouble(cubo, 0.0);
+        ay.setDouble(cubo, 0.0);
+        az.setDouble(cubo, 0.0);
+
+        double[][] mTop = new double[][]{
+            {0, 0, 1},
+            {-1, 1, 0},
+            {0, 0, 0}
+        };
+        rotField.set(cubo, mTop);
+        int[] resTop = call(new double[]{0, -1, 0}, 3);
+        assertEquals(0, resTop[0]);
+        assertEquals(1, resTop[1]);
+
+        double[][] mBottom = new double[][]{
+            {0, 0, 1},
+            {1, -1, 0},
+            {0, 0, 0}
+        };
+        rotField.set(cubo, mBottom);
+        int[] resBottom = call(new double[]{0, 1, 0}, 2);
+        assertEquals(0, resBottom[0]);
+        assertEquals(1, resBottom[1]);
     }
 }


### PR DESCRIPTION
## Summary
- Normalize arrow and normal vectors before computing cross products for rotation mapping
- Add explicit fallback for top and bottom faces when cross products are near zero, deriving axis from screen-space arrows
- Introduce unit tests covering extreme parallel cases for top/bottom faces

## Testing
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*
- `apt-get install -y ant` *(fails: unable to locate package)*


------
https://chatgpt.com/codex/tasks/task_e_68992618ca1483309fb3a0920277b5de