### PR TITLE
Explicit arrow-face mapping for rotations

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -8,19 +8,11 @@
    - Press `Enter` to enable game mode.
    - Click on a subcube to select it (highlighted).
 
-3. **UP Arrow Test**
-   - Select the front face subcube in the upper-left corner (`F1`).
-   - Rotate the whole cube arbitrarily using mouse drag or `I/J/K/L` keys.
-   - Press `UP` arrow.
-   - Verify that the layer containing `F1`, `F4`, and `F7` rotates upward regardless of cube orientation.
+3. **Face and Arrow Coverage**
+   - For each of the six faces (front, back, left, right, top, bottom):
+     - Select a subcube on that face.
+     - Press each arrow key (`UP`, `DOWN`, `LEFT`, `RIGHT`).
+     - Ensure the rotation axis and direction match the documented clockwise convention for the current face.
 
-4. **DOWN Arrow Test**
-   - With a subcube on any face selected, press `DOWN`.
-   - The layer containing the selected cube should rotate downward (opposite of `UP`).
-
-5. **LEFT/RIGHT Arrow Tests**
-   - Select subcubes on different faces and press `LEFT` and `RIGHT`.
-   - The layer containing the selected cube should rotate left or right relative to the selected face orientation.
-
-6. **Regression**
-   - Repeat steps with the cube oriented differently or after prior rotations to ensure arrow keys continue to use the selected face orientation.
+4. **Regression**
+   - Repeat the above with the cube oriented differently or after prior rotations to ensure arrow keys continue to use the selected face orientation.

--- a/test/main/CuboArrowRotationTest.java
+++ b/test/main/CuboArrowRotationTest.java
@@ -59,6 +59,55 @@ public class CuboArrowRotationTest {
     }
 
     @Test
+    public void testArrowRotationAllFacesAfterRotation() throws Exception {
+        // Apply a combination of rotations and ensure mapping holds for all faces
+        applyRot.invoke(cubo, 0, 30.0); // around X
+        applyRot.invoke(cubo, 1, 45.0); // around Y
+        Object[][] cases = new Object[][]{
+            // front face (1)
+            {1, new double[]{0, -1, 0}, 0, 0},
+            {1, new double[]{0, 1, 0}, 0, 1},
+            {1, new double[]{-1, 0, 0}, 1, 1},
+            {1, new double[]{1, 0, 0}, 1, 0},
+            // back face (0)
+            {0, new double[]{0, -1, 0}, 0, 1},
+            {0, new double[]{0, 1, 0}, 0, 0},
+            {0, new double[]{-1, 0, 0}, 1, 0},
+            {0, new double[]{1, 0, 0}, 1, 1},
+            // left face (4)
+            {4, new double[]{0, -1, 0}, 0, 0},
+            {4, new double[]{0, 1, 0}, 0, 1},
+            {4, new double[]{-1, 0, 0}, 1, 1},
+            {4, new double[]{1, 0, 0}, 1, 0},
+            // right face (5)
+            {5, new double[]{0, -1, 0}, 0, 1},
+            {5, new double[]{0, 1, 0}, 0, 0},
+            {5, new double[]{-1, 0, 0}, 1, 0},
+            {5, new double[]{1, 0, 0}, 1, 1},
+            // top face (3)
+            {3, new double[]{0, -1, 0}, 2, 0},
+            {3, new double[]{0, 1, 0}, 2, 1},
+            {3, new double[]{-1, 0, 0}, 2, 1},
+            {3, new double[]{1, 0, 0}, 2, 0},
+            // bottom face (2)
+            {2, new double[]{0, -1, 0}, 2, 0},
+            {2, new double[]{0, 1, 0}, 2, 1},
+            {2, new double[]{-1, 0, 0}, 2, 0},
+            {2, new double[]{1, 0, 0}, 2, 1}
+        };
+
+        for (Object[] c : cases) {
+            int face = (Integer) c[0];
+            double[] arrow = (double[]) c[1];
+            int expAxis = (Integer) c[2];
+            int expCw = (Integer) c[3];
+            int[] res = call(arrow, face);
+            assertEquals("axis for face " + face, expAxis, res[0]);
+            assertEquals("cw for face " + face, expCw, res[1]);
+        }
+    }
+
+    @Test
     public void testArrowRotation() throws Exception {
         // expected mapping: face index, arrow vector, axis, cw flag
         Object[][] cases = new Object[][]{


### PR DESCRIPTION
## Summary
- Refactor `getArrowRotation` to classify faces by dominant normal and map arrow keys to predefined axes
- Document clockwise conventions for each face and update manual test plan
- Add unit tests verifying rotations on all faces after arbitrary cube rotation

## Testing
- `javac $(find src/main -name "*.java")`
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689931792b248330b6c82d17ad8f99b9