### PR TITLE
Use rotated arrow vector for cw determination

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -445,25 +445,25 @@ public class Cubo extends JFrame {
             case 0: // Caras izquierda/derecha (normal en X)
                 axis = vertical ? 0 : 1;
                 if (vertical) {
-                    cw = (arrowVec[1] > 0) ^ (sign > 0);
+                    cw = (rArrow[1] > 0) ^ (sign > 0);
                 } else {
-                    cw = (arrowVec[0] < 0) ^ (sign > 0);
+                    cw = (rArrow[0] < 0) ^ (sign > 0);
                 }
                 break;
             case 1: // Caras frente/atrás (normal en Y)
                 axis = vertical ? 0 : 1;
                 if (vertical) {
-                    cw = (arrowVec[1] > 0) ^ (sign < 0);
+                    cw = (rArrow[1] > 0) ^ (sign < 0);
                 } else {
-                    cw = (arrowVec[0] < 0) ^ (sign < 0);
+                    cw = (rArrow[0] < 0) ^ (sign < 0);
                 }
                 break;
             default: // Caras arriba/abajo (normal en Z)
                 axis = 2;
                 if (vertical) {
-                    cw = arrowVec[1] > 0;
+                    cw = rArrow[1] > 0;
                 } else {
-                    cw = (arrowVec[0] < 0) ^ (sign < 0);
+                    cw = (rArrow[0] < 0) ^ (sign < 0);
                 }
                 break;
         }


### PR DESCRIPTION
## Summary
- base rotation direction on rotated arrow vector in `Cubo.getArrowRotation`

## Testing
- `javac -d /tmp/classes $(find src/main -name '*.java')`
- `ant test` *(fails: ant missing; `apt-get update` returned 403 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689938378c488330831078c09084387f