### PR TITLE
Fix arrow rotation direction for top and bottom faces

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -463,7 +463,7 @@ public class Cubo extends JFrame {
                 if (vertical) {
                     cw = rArrow[1] > 0;
                 } else {
-                    cw = (rArrow[0] < 0) ^ (sign < 0);
+                    cw = (rArrow[0] > 0) ^ (sign < 0);
                 }
                 break;
         }


### PR DESCRIPTION
## Summary
- Correct horizontal arrow rotation for top/bottom faces by using rotated vector and proper sign comparison.

## Testing
- `javac -d build $(find src/main -name '*.java')`
- `java -cp build:. RunCheck` *(custom harness: Top face right arrow -> cw; Bottom face left arrow -> cw)*
- `ant test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899391e371c8330a0022daed69b91ba