### PR TITLE
Solicitar foco del panel tras mostrar ventana

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -1247,9 +1247,9 @@ public class Cubo extends JFrame {
 
         // El panel debe poder enfocarse para captar las teclas
         panel.setFocusable(true);
-        panel.requestFocusInWindow(); // Asegura la recepción de eventos de teclado
 
         setVisible(true);
+        SwingUtilities.invokeLater(panel::requestFocusInWindow); // Asegura la recepción de eventos de teclado
     }
 
     /**


### PR DESCRIPTION
## Summary
- Solicita el foco del panel luego de mostrar la ventana, usando `SwingUtilities.invokeLater` para garantizar que el panel capture las teclas al inicio.

## Testing
- `javac -cp build/classes:/usr/share/java/junit4.jar -d build/test-classes $(find test -name '*.java')` *(falló: package org.junit does not exist)*
- `timeout 5 java -Djava.awt.headless=true -cp build/classes main.Cubo` *(falló: HeadlessException)*

------
https://chatgpt.com/codex/tasks/task_e_68993e753aa48330bf22d707066f366c