### PR TITLE
Fix animation direction to match final rotation

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -603,7 +603,7 @@ public class Cubo extends JFrame {
             return;
         }
         animating = true;
-        int dir = clockwise ? 1 : -1;
+        int dir = clockwise ? -1 : 1;
         double offset = (layer - 1) * size * escala;
 
         final int[] ang = {0};


### PR DESCRIPTION
## Summary
- flip rotation direction sign for clockwise turns in rotateLayerAnimated
- ensure per-frame and extra rotations use updated direction multiplier

## Testing
- `javac src/main/*.java`
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689957676de8833096207ec6d5ab18c3