### PR TITLE
Handle global rotations when mapping face arrows

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -421,9 +421,8 @@ public class Cubo extends JFrame {
      * grupo de caras.</p>
      */
     private int[] getArrowRotation(double[] arrowVec, Subcubo sc, int face) {
-        double[] rArrow = rotateVector(arrowVec, -anguloX, -anguloY, -anguloZ);
-        double[] normal = normalize(sc.getFaceNormalWorld(face));
-        rArrow = normalize(rArrow);
+        double[] rArrow = normalize(arrowVec);
+        double[] normal = normalize(sc.getFaceNormalGlobal(face, anguloX, anguloY, anguloZ));
 
         // Eje dominante de la cara seleccionada
         int faceAxis = 0;

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -246,6 +246,21 @@ public class Subcubo {
     }
 
     /**
+     * Devuelve la normal de una cara transformada por las rotaciones globales
+     * del cubo.
+     *
+     * @param face    índice de la cara
+     * @param anguloX rotación global en X
+     * @param anguloY rotación global en Y
+     * @param anguloZ rotación global en Z
+     * @return vector normal transformado al espacio global
+     */
+    public double[] getFaceNormalGlobal(int face, double anguloX, double anguloY, double anguloZ) {
+        double[] world = getFaceNormalWorld(face);
+        return rotar(world, anguloX, anguloY, anguloZ);
+    }
+
+    /**
      * Dibuja el subcubo aplicando las transformaciones indicadas.
      */
     public void dibujar(Graficos g, double escala, double anguloX, double anguloY, double anguloZ,

--- a/test/main/CuboArrowRotationTest.java
+++ b/test/main/CuboArrowRotationTest.java
@@ -59,6 +59,27 @@ public class CuboArrowRotationTest {
     }
 
     @Test
+    public void testArrowRotationAfterGlobalZRotation() throws Exception {
+        applyRot.invoke(cubo, 2, 90.0); // rotate around Z
+        Object[][] cases = new Object[][]{
+            {1, new double[]{0, -1, 0}, 1, 1},
+            {1, new double[]{0, 1, 0}, 1, 0},
+            {1, new double[]{-1, 0, 0}, 0, 0},
+            {1, new double[]{1, 0, 0}, 0, 1}
+        };
+
+        for (Object[] c : cases) {
+            int face = (Integer) c[0];
+            double[] arrow = (double[]) c[1];
+            int expAxis = (Integer) c[2];
+            int expCw = (Integer) c[3];
+            int[] res = call(arrow, face);
+            assertEquals("axis for face " + face, expAxis, res[0]);
+            assertEquals("cw for face " + face, expCw, res[1]);
+        }
+    }
+
+    @Test
     public void testArrowRotationAllFacesAfterRotation() throws Exception {
         // Apply a combination of rotations and ensure mapping holds for all faces
         applyRot.invoke(cubo, 0, 30.0); // around X


### PR DESCRIPTION
## Summary
- Expose Subcubo#getFaceNormalGlobal to return a face normal including global cube rotations
- Use global face normals in Cubo.getArrowRotation for consistent axis selection
- Add regression test verifying arrow mapping after Z-axis rotations

## Testing
- `ant test` *(fails: command not found)*
- `javac -cp /tmp/classes -d /tmp/test-classes $(find test/main -name "*.java")` *(fails: package org.junit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68995951fec083308ef59d4e060f6fa1