### PR TITLE
Clarify arrow rotation sign evaluation

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -453,7 +453,14 @@ public class Cubo extends JFrame {
                 maxComp = Math.abs(axisVec[i]);
             }
         }
-        boolean cw = (axisVec[axis] * normal[faceAxis] > 0) ^ (normal[faceAxis] > 0);
+        double axisComp = axisVec[axis];
+        double faceNorm = normal[faceAxis];
+        boolean cw;
+        if (faceNorm > 0) {
+            cw = axisComp <= 0;
+        } else {
+            cw = axisComp < 0;
+        }
         return new int[]{axis, cw ? 1 : 0};
     }
 


### PR DESCRIPTION
## Summary
- Replace XOR-based clockwise check with explicit sign comparison between rotation axis and face normal

## Testing
- `ant test` *(fails: command not found)*
- `java -cp out ManualArrowTest | head -n 40`


------
https://chatgpt.com/codex/tasks/task_e_68996dfc52c883308e846c9508f22f89