### PR TITLE
Align animated rotation direction

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -593,7 +593,7 @@ public class Cubo extends JFrame {
             return;
         }
         animating = true;
-        int dir = clockwise ? -1 : 1;
+        int dir = clockwise ? 1 : -1;
         double offset = (layer - 1) * size * escala;
 
         final int[] ang = {0};


### PR DESCRIPTION
## Summary
- Fix `rotateLayerAnimated` to use clockwise direction consistent with `rotateLayer`

## Testing
- `javac @/tmp/sources.txt -d /tmp/out`
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68996f938be8833099a5bd0f1f04e833