### PR TITLE
Refactor rotateLayer and add full-cycle test

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -172,70 +172,88 @@ public class Cubo extends JFrame {
      * piezas que la componen.
      */
     private void rotateLayer(int axis, int layer, boolean clockwise) {
-        Subcubo[][][] nuevo = new Subcubo[3][3][3];
+        Subcubo[][] temp = new Subcubo[3][3];
 
-        // Copiar todas las piezas inicialmente
-        for (int x = 0; x < 3; x++) {
-            for (int y = 0; y < 3; y++) {
-                for (int z = 0; z < 3; z++) {
-                    nuevo[x][y][z] = cuboRubik[x][y][z];
-                }
-            }
-        }
-
-        // Aplicar la rotación a la capa indicada
-        for (int x = 0; x < 3; x++) {
-            for (int y = 0; y < 3; y++) {
-                for (int z = 0; z < 3; z++) {
-                    if ((axis == 0 && x == layer) ||
-                        (axis == 1 && y == layer) ||
-                        (axis == 2 && z == layer)) {
-
-                        int nx = x, ny = y, nz = z;
-
-                        switch (axis) {
-                            case 0: // X
-                                if (clockwise) {
-                                    ny = z;
-                                    nz = 2 - y;
-                                } else {
-                                    ny = 2 - z;
-                                    nz = y;
-                                }
-                                break;
-                            case 1: // Y
-                                if (clockwise) {
-                                    nx = 2 - z;
-                                    nz = x;
-                                } else {
-                                    nx = z;
-                                    nz = 2 - x;
-                                }
-                                break;
-                            case 2: // Z
-                                if (clockwise) {
-                                    nx = y;
-                                    ny = 2 - x;
-                                } else {
-                                    nx = 2 - y;
-                                    ny = x;
-                                }
-                                break;
-                        }
-
-                        Subcubo moved = cuboRubik[x][y][z];
-                        nuevo[nx][ny][nz] = moved;
-                        moved.x = nx;
-                        moved.y = ny;
-                        moved.z = nz;
-                        moved.rotateColors(axis, clockwise);
-                        moved.applyGlobalRotation(axis, clockwise);
+        switch (axis) {
+            case 0: // X axis, rotate in YZ plane
+                for (int y = 0; y < 3; y++) {
+                    for (int z = 0; z < 3; z++) {
+                        temp[y][z] = cuboRubik[layer][y][z];
                     }
                 }
-            }
+                for (int y = 0; y < 3; y++) {
+                    for (int z = 0; z < 3; z++) {
+                        int ny, nz;
+                        if (clockwise) {
+                            ny = z;
+                            nz = 2 - y;
+                        } else {
+                            ny = 2 - z;
+                            nz = y;
+                        }
+                        Subcubo sc = temp[y][z];
+                        cuboRubik[layer][ny][nz] = sc;
+                        sc.x = layer;
+                        sc.y = ny;
+                        sc.z = nz;
+                        sc.rotateColors(axis, clockwise);
+                        sc.applyGlobalRotation(axis, clockwise);
+                    }
+                }
+                break;
+            case 1: // Y axis, rotate in XZ plane
+                for (int x = 0; x < 3; x++) {
+                    for (int z = 0; z < 3; z++) {
+                        temp[x][z] = cuboRubik[x][layer][z];
+                    }
+                }
+                for (int x = 0; x < 3; x++) {
+                    for (int z = 0; z < 3; z++) {
+                        int nx, nz;
+                        if (clockwise) {
+                            nx = 2 - z;
+                            nz = x;
+                        } else {
+                            nx = z;
+                            nz = 2 - x;
+                        }
+                        Subcubo sc = temp[x][z];
+                        cuboRubik[nx][layer][nz] = sc;
+                        sc.x = nx;
+                        sc.y = layer;
+                        sc.z = nz;
+                        sc.rotateColors(axis, clockwise);
+                        sc.applyGlobalRotation(axis, clockwise);
+                    }
+                }
+                break;
+            case 2: // Z axis, rotate in XY plane
+                for (int x = 0; x < 3; x++) {
+                    for (int y = 0; y < 3; y++) {
+                        temp[x][y] = cuboRubik[x][y][layer];
+                    }
+                }
+                for (int x = 0; x < 3; x++) {
+                    for (int y = 0; y < 3; y++) {
+                        int nx, ny;
+                        if (clockwise) {
+                            nx = y;
+                            ny = 2 - x;
+                        } else {
+                            nx = 2 - y;
+                            ny = x;
+                        }
+                        Subcubo sc = temp[x][y];
+                        cuboRubik[nx][ny][layer] = sc;
+                        sc.x = nx;
+                        sc.y = ny;
+                        sc.z = layer;
+                        sc.rotateColors(axis, clockwise);
+                        sc.applyGlobalRotation(axis, clockwise);
+                    }
+                }
+                break;
         }
-
-        cuboRubik = nuevo;
     }
 
     /**

--- a/test/main/RotateLayerFullCycleTest.java
+++ b/test/main/RotateLayerFullCycleTest.java
@@ -1,0 +1,75 @@
+package main;
+
+import static org.junit.Assert.*;
+
+import java.awt.Color;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.Test;
+
+public class RotateLayerFullCycleTest {
+
+    @Test
+    public void layerReturnsToOriginalAfterFourRotations() throws Exception {
+        System.setProperty("java.awt.headless", "true");
+        Method rotateLayer = Cubo.class.getDeclaredMethod("rotateLayer", int.class, int.class, boolean.class);
+        rotateLayer.setAccessible(true);
+        Field cuboField = Cubo.class.getDeclaredField("cuboRubik");
+        cuboField.setAccessible(true);
+        Field colorField = Subcubo.class.getDeclaredField("colores");
+        colorField.setAccessible(true);
+        Field matrixField = Subcubo.class.getDeclaredField("rotMatrix");
+        matrixField.setAccessible(true);
+
+        for (int axis = 0; axis < 3; axis++) {
+            for (int layer = 0; layer < 3; layer++) {
+                Cubo c = new Cubo();
+                Subcubo[][][] cubo = (Subcubo[][][]) cuboField.get(c);
+
+                Subcubo[][][] origRef = new Subcubo[3][3][3];
+                Color[][][][] origColors = new Color[3][3][3][];
+                double[][][][] origMatrix = new double[3][3][3][][];
+
+                for (int x = 0; x < 3; x++) {
+                    for (int y = 0; y < 3; y++) {
+                        for (int z = 0; z < 3; z++) {
+                            Subcubo sc = cubo[x][y][z];
+                            origRef[x][y][z] = sc;
+                            origColors[x][y][z] = ((Color[]) colorField.get(sc)).clone();
+                            double[][] m = (double[][]) matrixField.get(sc);
+                            double[][] mc = new double[m.length][m[0].length];
+                            for (int r = 0; r < m.length; r++) {
+                                mc[r] = m[r].clone();
+                            }
+                            origMatrix[x][y][z] = mc;
+                        }
+                    }
+                }
+
+                for (int i = 0; i < 4; i++) {
+                    rotateLayer.invoke(c, axis, layer, true);
+                }
+                cubo = (Subcubo[][][]) cuboField.get(c);
+
+                for (int x = 0; x < 3; x++) {
+                    for (int y = 0; y < 3; y++) {
+                        for (int z = 0; z < 3; z++) {
+                            Subcubo sc = cubo[x][y][z];
+                            assertSame("axis=" + axis + " layer=" + layer + " pos=" + x + "," + y + "," + z,
+                                    origRef[x][y][z], sc);
+                            Color[] expectedColors = origColors[x][y][z];
+                            Color[] actualColors = (Color[]) colorField.get(sc);
+                            assertArrayEquals(expectedColors, actualColors);
+                            double[][] expectedM = origMatrix[x][y][z];
+                            double[][] actualM = (double[][]) matrixField.get(sc);
+                            for (int r = 0; r < 3; r++) {
+                                assertArrayEquals(expectedM[r], actualM[r], 1e-9);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Refactor `rotateLayer` to rotate only the selected layer and update only affected subcubes
- Add `RotateLayerFullCycleTest` verifying four rotations return the cube to its original state

## Testing
- `javac -d /tmp/classes $(find src/main -name '*.java')`
- `ant test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689997c8bed883309b83461bb41f5019