### PR TITLE
Map parallel arrow drags using face-local lookup table

### DIFF
--- a/test/main/ArrowParallelNormalTest.java
+++ b/test/main/ArrowParallelNormalTest.java
@@ -1,0 +1,62 @@
+package main;
+
+import static org.junit.Assert.*;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ArrowParallelNormalTest {
+
+    private Cubo cubo;
+    private Method getArrow;
+
+    @Before
+    public void setUp() throws Exception {
+        System.setProperty("java.awt.headless", "true");
+        cubo = new Cubo();
+        getArrow = Cubo.class.getDeclaredMethod("getArrowRotation", double[].class, Subcubo.class, int.class);
+        getArrow.setAccessible(true);
+        // reset orientation to identity for deterministic normals
+        Field ax = Cubo.class.getDeclaredField("anguloX");
+        Field ay = Cubo.class.getDeclaredField("anguloY");
+        Field az = Cubo.class.getDeclaredField("anguloZ");
+        ax.setAccessible(true);
+        ay.setAccessible(true);
+        az.setAccessible(true);
+        ax.setDouble(cubo, 0.0);
+        ay.setDouble(cubo, 0.0);
+        az.setDouble(cubo, 0.0);
+        Field rot = Cubo.class.getDeclaredField("rotMatrix");
+        rot.setAccessible(true);
+        rot.set(cubo, new double[][]{{1,0,0},{0,1,0},{0,0,1}});
+    }
+
+    private int[] call(double[] arrow, int face) throws Exception {
+        Subcubo sc = new Subcubo(0,0,0,1);
+        return (int[]) getArrow.invoke(cubo, arrow, sc, face);
+    }
+
+    @Test
+    public void testParallelToNormalAllFaces() throws Exception {
+        Object[][] cases = new Object[][]{
+            {0, Subcubo.getFaceNormal(0), 0, 0},
+            {1, Subcubo.getFaceNormal(1), 0, 0},
+            {2, Subcubo.getFaceNormal(2), 0, 1},
+            {3, Subcubo.getFaceNormal(3), 0, 0},
+            {4, Subcubo.getFaceNormal(4), 1, 1},
+            {5, Subcubo.getFaceNormal(5), 1, 1}
+        };
+        for (Object[] c : cases) {
+            int face = (Integer) c[0];
+            double[] arrow = (double[]) c[1];
+            int expAxis = (Integer) c[2];
+            int expCw = (Integer) c[3];
+            int[] res = call(arrow, face);
+            assertEquals("axis for face " + face, expAxis, res[0]);
+            assertEquals("cw for face " + face, expCw, res[1]);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Convert arrow and face normals to cube-local space and map parallel drags through a lookup table.
- Introduce helper to derive face orientation from normals and table-driven axis/clockwise results.
- Add unit tests covering arrow vectors parallel to each face normal.

## Testing
- `javac -d out $(find src/main -name '*.java')`
- `javac -d out -cp out $(find test -name '*.java')` *(fails: package org.junit does not exist)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68999a29a3b08330ac15ef70b843b465