### PR TITLE
Rebuild rotation matrices using cross products

### DIFF
--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -438,6 +438,37 @@ public class Subcubo {
     }
 
     /**
+     * Producto cruz entre dos vectores de 3 componentes.
+     */
+    private static double[] cross(double[] a, double[] b) {
+        return new double[]{
+            a[1] * b[2] - a[2] * b[1],
+            a[2] * b[0] - a[0] * b[2],
+            a[0] * b[1] - a[1] * b[0]
+        };
+    }
+
+    /**
+     * Producto punto entre dos vectores de 3 componentes.
+     */
+    private static double dot(double[] a, double[] b) {
+        return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+    }
+
+    /**
+     * Normaliza un vector a longitud 1.
+     */
+    private static void normalize(double[] v) {
+        double len = Math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+        if (len == 0) {
+            return;
+        }
+        v[0] /= len;
+        v[1] /= len;
+        v[2] /= len;
+    }
+
+    /**
      * Normaliza la matriz de rotación acumulada {@link #rotMatrix} corrigiendo
      * pequeñas desviaciones numéricas para mantenerla en un estado discreto
      * (valores -1, 0 o 1). Esto evita la acumulación de errores tras muchas
@@ -459,9 +490,10 @@ public class Subcubo {
                 }
             }
         }
-        // Reconstruir a partir de estados discretos para garantizar
-        // ortogonalidad y evitar acumulación de errores.
-        double[][] rebuilt = new double[3][3];
+        // Reconstruir a partir de estados discretos garantizando una base
+        // ortonormal y con determinante 1. Seleccionamos el eje dominante de
+        // cada fila y usamos un producto cruz para obtener el tercer eje.
+        double[][] axes = new double[3][3];
         for (int i = 0; i < 3; i++) {
             int maxIdx = 0;
             for (int j = 1; j < 3; j++) {
@@ -470,9 +502,19 @@ public class Subcubo {
                 }
             }
             double sign = Math.signum(rotMatrix[i][maxIdx]);
-            rebuilt[i][maxIdx] = sign == 0 ? 1 : sign;
+            axes[i][maxIdx] = sign == 0 ? 1 : sign;
         }
-        rotMatrix = rebuilt;
+        double[] cross = cross(axes[0], axes[1]);
+        normalize(cross);
+        // Alinear el tercer eje con el signo originalmente detectado para la
+        // tercera fila
+        if (dot(cross, axes[2]) < 0) {
+            for (int i = 0; i < 3; i++) {
+                cross[i] = -cross[i];
+            }
+        }
+        axes[2] = cross;
+        rotMatrix = axes;
     }
 
     /**

--- a/test/main/LongScrambleOrientationTest.java
+++ b/test/main/LongScrambleOrientationTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 public class LongScrambleOrientationTest {
 
     @Test
-    public void testOrientationStaysDiscreteAfterLongScramble() throws Exception {
+    public void testOrientationStaysValidAfterLongScramble() throws Exception {
         Subcubo sc = new Subcubo(0, 0, 0, 1);
         Random rnd = new Random(42);
         for (int i = 0; i < 1000; i++) {
@@ -25,6 +25,16 @@ public class LongScrambleOrientationTest {
                 double v = m[i][j];
                 assertTrue("Matrix entry not discrete: " + v, v == 0.0 || v == 1.0 || v == -1.0);
             }
+            double norm = m[i][0] * m[i][0] + m[i][1] * m[i][1] + m[i][2] * m[i][2];
+            assertEquals("Row not unit length", 1.0, norm, 1e-9);
+            for (int j = i + 1; j < 3; j++) {
+                double dot = m[i][0] * m[j][0] + m[i][1] * m[j][1] + m[i][2] * m[j][2];
+                assertEquals("Rows not orthogonal", 0.0, dot, 1e-9);
+            }
         }
+        double det = m[0][0] * (m[1][1] * m[2][2] - m[1][2] * m[2][1])
+                - m[0][1] * (m[1][0] * m[2][2] - m[1][2] * m[2][0])
+                + m[0][2] * (m[1][0] * m[2][1] - m[1][1] * m[2][0]);
+        assertEquals("Determinant is not 1", 1.0, det, 1e-9);
     }
 }


### PR DESCRIPTION
## Summary
- Reconstruct cubelet orientation using dominant axes and cross products to keep rotations orthonormal with determinant 1.
- Add vector utility helpers for cross product, dot product and normalization.
- Expand long scramble test to verify matrix discreteness, orthogonality and determinant.

## Testing
- `ant test` *(fails: command not found)*
- `java -cp out TestRunner`


------
https://chatgpt.com/codex/tasks/task_e_68999c6169b0833088ea13b39b55173c