### PR TITLE
Use upward Y-axis for cube faces

### DIFF
--- a/src/main/Cubo.java
+++ b/src/main/Cubo.java
@@ -424,7 +424,7 @@ public class Cubo extends JFrame {
             case 0:
                 return sign > 0 ? 5 : 4;
             case 1:
-                return sign > 0 ? 2 : 3;
+                return sign > 0 ? 3 : 2;
             default:
                 return sign > 0 ? 1 : 0;
         }

--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -200,9 +200,9 @@ public class Subcubo {
             case 1: // front
                 return new double[]{0, 0, 1};
             case 2: // bottom
-                return new double[]{0, 1, 0};
-            case 3: // top
                 return new double[]{0, -1, 0};
+            case 3: // top
+                return new double[]{0, 1, 0};
             case 4: // left
                 return new double[]{-1, 0, 0};
             case 5: // right


### PR DESCRIPTION
## Summary
- Update Subcubo face normals so the top face uses `{0,1,0}` and bottom uses `{0,-1,0}`
- Adjust orientation and rotation logic to match the new Y-axis convention

## Testing
- `javac @sources.txt @testsources.txt` *(fails: package org.junit does not exist)*
- `jshell --class-path src` manual `getArrowRotation` check
- `jshell --class-path src` manual global rotation normal check

------
https://chatgpt.com/codex/tasks/task_e_6899a2ab94008330b8c9a8a8914116a9