### PR TITLE
Align X-axis color cycle with layer permutation

### DIFF
--- a/src/main/Subcubo.java
+++ b/src/main/Subcubo.java
@@ -51,7 +51,7 @@ public class Subcubo {
      * en sentido horario alrededor del eje correspondiente.
      */
     private static final int[][] FACE_CYCLES = {
-        {0, 3, 1, 2}, // X axis: back -> top -> front -> bottom
+        {0, 2, 1, 3}, // X axis: back -> bottom -> front -> top
         {0, 4, 1, 5}, // Y axis: back -> left -> front -> right
         {3, 5, 2, 4}  // Z axis: top -> right -> bottom -> left
     };

--- a/test/main/RotateLayerFullCycleTest.java
+++ b/test/main/RotateLayerFullCycleTest.java
@@ -29,7 +29,7 @@ public class RotateLayerFullCycleTest {
 
                 Subcubo[][][] origRef = new Subcubo[3][3][3];
                 Color[][][][] origColors = new Color[3][3][3][];
-                double[][][][] origMatrix = new double[3][3][3][][];
+                double[][][][][] origMatrix = new double[3][3][3][3][3];
 
                 for (int x = 0; x < 3; x++) {
                     for (int y = 0; y < 3; y++) {
@@ -49,6 +49,69 @@ public class RotateLayerFullCycleTest {
 
                 for (int i = 0; i < 4; i++) {
                     rotateLayer.invoke(c, axis, layer, true);
+                }
+                cubo = (Subcubo[][][]) cuboField.get(c);
+
+                for (int x = 0; x < 3; x++) {
+                    for (int y = 0; y < 3; y++) {
+                        for (int z = 0; z < 3; z++) {
+                            Subcubo sc = cubo[x][y][z];
+                            assertSame("axis=" + axis + " layer=" + layer + " pos=" + x + "," + y + "," + z,
+                                    origRef[x][y][z], sc);
+                            Color[] expectedColors = origColors[x][y][z];
+                            Color[] actualColors = (Color[]) colorField.get(sc);
+                            assertArrayEquals(expectedColors, actualColors);
+                            double[][] expectedM = origMatrix[x][y][z];
+                            double[][] actualM = (double[][]) matrixField.get(sc);
+                            for (int r = 0; r < 3; r++) {
+                                assertArrayEquals(expectedM[r], actualM[r], 1e-9);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void layerReturnsToOriginalAfterFourCounterRotations() throws Exception {
+        System.setProperty("java.awt.headless", "true");
+        Method rotateLayer = Cubo.class.getDeclaredMethod("rotateLayer", int.class, int.class, boolean.class);
+        rotateLayer.setAccessible(true);
+        Field cuboField = Cubo.class.getDeclaredField("cuboRubik");
+        cuboField.setAccessible(true);
+        Field colorField = Subcubo.class.getDeclaredField("colores");
+        colorField.setAccessible(true);
+        Field matrixField = Subcubo.class.getDeclaredField("rotMatrix");
+        matrixField.setAccessible(true);
+
+        for (int axis = 0; axis < 3; axis++) {
+            for (int layer = 0; layer < 3; layer++) {
+                Cubo c = new Cubo();
+                Subcubo[][][] cubo = (Subcubo[][][]) cuboField.get(c);
+
+                Subcubo[][][] origRef = new Subcubo[3][3][3];
+                Color[][][][] origColors = new Color[3][3][3][];
+                double[][][][][] origMatrix = new double[3][3][3][3][3];
+
+                for (int x = 0; x < 3; x++) {
+                    for (int y = 0; y < 3; y++) {
+                        for (int z = 0; z < 3; z++) {
+                            Subcubo sc = cubo[x][y][z];
+                            origRef[x][y][z] = sc;
+                            origColors[x][y][z] = ((Color[]) colorField.get(sc)).clone();
+                            double[][] m = (double[][]) matrixField.get(sc);
+                            double[][] mc = new double[m.length][m[0].length];
+                            for (int r = 0; r < m.length; r++) {
+                                mc[r] = m[r].clone();
+                            }
+                            origMatrix[x][y][z] = mc;
+                        }
+                    }
+                }
+
+                for (int i = 0; i < 4; i++) {
+                    rotateLayer.invoke(c, axis, layer, false);
                 }
                 cubo = (Subcubo[][][]) cuboField.get(c);
 

--- a/test/main/SubcuboColorRotationTest.java
+++ b/test/main/SubcuboColorRotationTest.java
@@ -29,15 +29,15 @@ public class SubcuboColorRotationTest {
         switch (axis) {
             case 0:
                 if (cw) {
-                    r[0] = c[2];
-                    r[1] = c[3];
-                    r[2] = c[1];
-                    r[3] = c[0];
-                } else {
                     r[0] = c[3];
                     r[1] = c[2];
                     r[2] = c[0];
                     r[3] = c[1];
+                } else {
+                    r[0] = c[2];
+                    r[1] = c[3];
+                    r[2] = c[1];
+                    r[3] = c[0];
                 }
                 break;
             case 1:


### PR DESCRIPTION
## Summary
- Correct X-axis FACE_CYCLES so colors rotate in the same order as subcubes
- Adjust SubcuboColorRotationTest expectations for new color cycle
- Add regression test ensuring four counterclockwise layer rotations return cube to original state

## Testing
- `javac -cp src $(find src -name '*.java') $(find test -name '*.java')` *(fails: package org.junit does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6899a77a64c88330a96dec0ac08002c4